### PR TITLE
[SETTING] index.css 공통 작업

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,19 @@
 @import 'tailwindcss';
 
+@theme {
+  /* Gray Scale */
+  --color-gray-100: #ffffff;
+  --color-gray-200: #f3f3f3;
+  --color-gray-300: #dcdcdc;
+  --color-gray-400: #aeaeae;
+  --color-gray-500: #777777;
+  --color-gray-600: #111111;
+
+  /* Primary Color */
+  --color-primary-blue: #132650;
+  --color-primary-variant-blue: #2e4475;
+}
+
 @layer utilities {
   /* Big Title (32px, SemiBold) */
   .font-bigtitle-sb {
@@ -115,4 +129,5 @@ html {
 }
 body {
   font-family: 'Poppins', Arial, sans-serif;
+  background-color: var(--color-gray-100);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,118 @@
 @import 'tailwindcss';
+
+@layer utilities {
+  /* Big Title (32px, SemiBold) */
+  .font-bigtitle-sb {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 3.2rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Big Title (32px, Regular) */
+  .font-bigtitle-r {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 3.2rem;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Title (24px, SemiBold) */
+  .font-title-sb {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 2.4rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Title (24px, Regular) */
+  .font-title-r {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 2.4rem;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Title/Sub (20px, SemiBold) */
+  .font-title-sub-sb {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 2rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Title/Sub (20px, Regular) */
+  .font-title-sub-r {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 2rem;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Body (16px, SemiBold) */
+  .font-body-sb {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Body (16px, Regular) */
+  .font-body-r {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 1.6rem;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Small (14px, SemiBold) */
+  .font-small-sb {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 1.4rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* Small (14px, Regular) */
+  .font-small-r {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 1.4rem;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* XSmall (12px, SemiBold) */
+  .font-xsmall-sb {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 1.2rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+
+  /* XSmall (12px, Regular) */
+  .font-xsmall-r {
+    font-family: 'Poppins', Arial, sans-serif;
+    font-size: 1.2rem;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: normal;
+  }
+}
+
+html {
+  font-size: 62.5%; /* 1rem = 10px */
+}
+body {
+  font-family: 'Poppins', Arial, sans-serif;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -21,7 +21,7 @@
     font-size: 3.2rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 150%;
   }
 
   /* Big Title (32px, Regular) */
@@ -30,7 +30,7 @@
     font-size: 3.2rem;
     font-weight: 400;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 150%;
   }
 
   /* Title (24px, SemiBold) */
@@ -39,7 +39,7 @@
     font-size: 2.4rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 150%;
   }
 
   /* Title (24px, Regular) */
@@ -48,7 +48,7 @@
     font-size: 2.4rem;
     font-weight: 400;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* Title/Sub (20px, SemiBold) */
@@ -57,7 +57,7 @@
     font-size: 2rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* Title/Sub (20px, Regular) */
@@ -66,7 +66,7 @@
     font-size: 2rem;
     font-weight: 400;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* Body (16px, SemiBold) */
@@ -75,7 +75,7 @@
     font-size: 1.6rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* Body (16px, Regular) */
@@ -84,7 +84,7 @@
     font-size: 1.6rem;
     font-weight: 400;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* Small (14px, SemiBold) */
@@ -93,7 +93,7 @@
     font-size: 1.4rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* Small (14px, Regular) */
@@ -102,7 +102,7 @@
     font-size: 1.4rem;
     font-weight: 400;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* XSmall (12px, SemiBold) */
@@ -111,7 +111,7 @@
     font-size: 1.2rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 
   /* XSmall (12px, Regular) */
@@ -120,7 +120,7 @@
     font-size: 1.2rem;
     font-weight: 400;
     letter-spacing: -0.02em;
-    line-height: normal;
+    line-height: 140%;
   }
 }
 


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #3 

---

### ✅ Key Changes

- Poppins 폰트 전체 적용
- 컬러칩 적용

---

### 📸 스크린샷 or 실행영상

<img src="https://github.com/user-attachments/assets/10e52e52-600e-4115-9849-74a7cf663229" width="400">
<img src="https://github.com/user-attachments/assets/1bac73c7-89c4-4ed7-b198-ff665bbb57cc" width="400">

<br />


---

### 💬 To Reviewers

**- 텍스트 속성**
<img src="https://github.com/user-attachments/assets/40f71e7e-ca4b-4206-878e-28181f28314d" width="400">
피그마 텍스트 선택 시 Name 기준으로 이름 지정하였습니다.
`className="font-title-sb"`, `className="font-body-r"` 로 font size 나 font weight 설정 없이 바로 적용 가능합니다.

**- rem , px 변환**
index.css 에 
<img src="https://github.com/user-attachments/assets/6994027e-874a-4666-8d8d-eb52160f89dd" width="400">

으로 설정하여 rem 단위로 작성하려면 4rem=40px 로 간편하게 변환 가능합니다.
`p-[4rem]` == `p-[40px]`  
<img src="https://github.com/user-attachments/assets/eccfc935-bd28-4b75-9483-be22b97646b9" width="300">

`tailwindcss-preset-px-to-rem` 라이브러리 적용이 잘 되지 않아 우선 바로 rem 으로 계산하여 코드에 적용할 수 있도록 하였습니다.

++ 커밋 타입 주의해서 대문자로 통일하겠습니다..!!