### PR TITLE
 [FEAT] 사이드바 라우팅 연결 및 Outlet 자식 레이아웃 구조 개선

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -5,8 +5,11 @@ import issueIcon from '../../assets/icons/issue.svg';
 import externalIcon from '../../assets/icons/external.svg';
 import documentIcon from '../../assets/icons/document.svg';
 import grayIcon from '../../assets/icons/gray.svg';
+import { useNavigate } from 'react-router-dom';
 
 const Sidebar = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="w-[28rem] bg-white p-4 shadow-lg min-h-screen">
       {/* 첫 번째 드롭다운: 작업실 */}
@@ -14,14 +17,22 @@ const Sidebar = () => {
         <SidebarItem
           icon={<img src={externalIcon} alt="External" />}
           label="나의 목표"
-          onAddClick={() => {}}
-          onClick={() => {}}
+          onClick={() => {
+            navigate('/my/mygoal');
+          }}
+          onAddClick={() => {
+            navigate('/my/mygoal/:myGoalId');
+          }}
         />
         <SidebarItem
           icon={<img src={documentIcon} alt="Document" />}
           label="나의 이슈"
-          onAddClick={() => {}}
-          onClick={() => {}}
+          onClick={() => {
+            navigate('/my/myissue');
+          }}
+          onAddClick={() => {
+            navigate('/my/myissue/:myIssueId');
+          }}
         />
       </DropdownMenu>
       <div className="my-4 border-b border-gray-200"></div> {/* 구분선 */}
@@ -38,24 +49,36 @@ const Sidebar = () => {
             <SidebarItem
               icon={<img src={goalIcon} alt="Goal" />}
               label="목표"
-              onAddClick={() => {}}
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/goal`);
+              }}
+              onAddClick={() => {
+                navigate(`/team/:teamId/goal/:goalId`);
+              }}
             />
             <SidebarItem
               icon={<img src={issueIcon} alt="Issue" />}
               label="이슈"
-              onAddClick={() => {}}
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/issue`);
+              }}
+              onAddClick={() => {
+                navigate(`/team/:teamId/issue/:issueId`);
+              }}
             />
             <SidebarItem
               icon={<img src={externalIcon} alt="External" />}
               label="외부"
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/ext`);
+              }}
             />
             <SidebarItem
               icon={<img src={documentIcon} alt="Document" />}
               label="문서"
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/doc`);
+              }}
             />
           </div>
         </DropdownMenu>
@@ -69,24 +92,36 @@ const Sidebar = () => {
             <SidebarItem
               icon={<img src={goalIcon} alt="Goal" />}
               label="목표"
-              onAddClick={() => {}}
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/goal`);
+              }}
+              onAddClick={() => {
+                navigate(`/team/:teamId/goal/:goalId`);
+              }}
             />
             <SidebarItem
               icon={<img src={issueIcon} alt="Issue" />}
               label="이슈"
-              onAddClick={() => {}}
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/issue`);
+              }}
+              onAddClick={() => {
+                navigate(`/team/:teamId/issue/:issueId`);
+              }}
             />
             <SidebarItem
               icon={<img src={externalIcon} alt="External" />}
               label="외부"
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/ext`);
+              }}
             />
             <SidebarItem
               icon={<img src={documentIcon} alt="Document" />}
               label="문서"
-              onClick={() => {}}
+              onClick={() => {
+                navigate(`/team/:teamId/doc`);
+              }}
             />
           </div>
         </DropdownMenu>

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -5,7 +5,9 @@ const ProtectedLayout = () => {
   return (
     <div className="flex">
       <Sidebar />
-      <Outlet />
+      <main className="flex-1 min-w-0 p-[3.2rem] overflow-auto">
+        <Outlet />
+      </main>
     </div>
   );
 };

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -3,8 +3,10 @@ import Sidebar from '../components/Sidebar/Sidebar';
 
 const ProtectedLayout = () => {
   return (
-    <div className="flex">
-      <Sidebar />
+    <div className="flex h-screen">
+      <aside className="overflow-auto">
+        <Sidebar />
+      </aside>
       <main className="flex-1 min-w-0 p-[3.2rem] overflow-auto">
         <Outlet />
       </main>

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -36,6 +36,8 @@ export const protectedRoutes: RouteObject[] = [
           { path: 'goal/:goalId', element: <div>{/* Goal_Detail 페이지 */}</div> },
           { path: 'issue', element: <div>{/* Issue_Home 페이지 */}</div> },
           { path: 'issue/:issueId', element: <div>{/* Issue_Detail 페이지 */}</div> },
+          { path: 'ext', element: <div>{/* External_Home 페이지 */}</div> },
+          { path: 'ext/:extId', element: <div>{/* External_Detail 페이지 */}</div> },
           { path: 'doc', element: <div>{/* Document_Home 페이지 */}</div> },
           { path: 'doc/:docId', element: <div>{/* Document_Detail 페이지 */}</div> },
         ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -1,4 +1,4 @@
-import { Navigate, type RouteObject } from 'react-router-dom';
+import { Navigate, Outlet, type RouteObject } from 'react-router-dom';
 import ProtectedLayout from '../layouts/ProtectedLayout';
 
 export const protectedRoutes: RouteObject[] = [
@@ -14,7 +14,7 @@ export const protectedRoutes: RouteObject[] = [
     children: [
       {
         path: 'my',
-        element: <div></div>, // Placeholder (필요시 컴포넌트로 변경하여 작성 후 연결)
+        element: <Outlet />, // Placeholder (필요시 컴포넌트로 변경하여 작성 후 연결)
         children: [
           // 기본 경로는 나의 이슈 페이지로 리다이렉트되게 했음. (문제시 변경)
           { index: true, element: <Navigate to="myissue" replace /> },
@@ -28,7 +28,7 @@ export const protectedRoutes: RouteObject[] = [
       },
       {
         path: 'team/:teamId',
-        element: <div></div>, // Placeholder (필요시 컴포넌트로 변경하여 작성 후 연결)
+        element: <Outlet />, // Placeholder (필요시 컴포넌트로 변경하여 작성 후 연결)
         children: [
           // 기본 경로는 이슈 페이지로 리다이렉트.
           { index: true, element: <Navigate to="issue" replace /> },


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- #25

---

### ✅ Key Changes

- 사이드바에서 아이템 클릭 시 해당하는 페이지로 라우팅
- 사이드바를 제외한 자식 요소 크기 및 패딩 처리
  - `main.flex-1` - 남은 공간 차지 : 사이드바를 제외한 나머지 영역을 main이 채움
  - `min-w-0` - 콘텐츠 넘침 방지 : flex item에서 overflow ellipsis나 줄바꿈 등 작동되도록 보장
  - `p-[3.2rem]` - 내부 여백 : main 내부 컨텐츠와 테두리 사이 간격 확보 (디자인 기준)
  - `overflow-auto` - 스크롤 활성화 : 콘텐츠가 main보다 크면 스크롤 가능하게 함

---

### 📸 스크린샷 or 실행영상
![image](https://github.com/user-attachments/assets/4e659e3d-b8bb-46f4-8b13-0d9708e30822)

---

### 💬 To Reviewers

- 앞으로 내용 여백은 main에서 `p-[3.2rem]`으로 적용하였으므로 별도 작성하실 필요 없습니다.
- 내부 자식에서 아래와 같이 배경 확장이 필요한 경우 `<div className="px-[3.2rem] -mx-[3.2rem] bg-...">` 로 작성하시면 패딩을 침범하여 배경 확장이 가능합니다.
![image](https://github.com/user-attachments/assets/8e0b600c-7d3d-47f5-84b5-1675bc1660c4)