### PR TITLE
[MOD] 페이지 라우팅 변경&추가

### DIFF
--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -5,43 +5,61 @@ import IssueHome from '../pages/issue/IssueHome';
 
 export const protectedRoutes: RouteObject[] = [
   {
-    path: '/',
-    element: <ProtectedLayout />, // ProtectedLayout을 위한 placeholder (추후 ProtectedLayout 컴포넌트 작성 후 연결.)
+    // 워크스페이스 내부 페이지들 : 로그인해야 들어올 수 있음
+    path: '/workspace',
+    element: <ProtectedLayout />,
     errorElement: <div>Not Found</div>,
 
-    /*
-      하위 경로 페이지들: 전부 placeholder 처리해둠.
-      필요시 각 페이지 파일 작성 후 연결하여 사용.
-    */
     children: [
+      { index: true, element: <Navigate to="team/default/issue" replace /> }, // 기본 경로는 team/default로 리다이렉트
+      /* 알람 페이지 */
       {
-        path: 'my',
-        element: <Outlet />, // Placeholder (필요시 컴포넌트로 변경하여 작성 후 연결)
+        path: 'noti',
+        element: <Outlet />,
+        children: [{ index: true, element: <div>Notification</div> }],
+      },
+      /* 설정 페이지들 */
+      {
+        path: 'setting',
+        element: <Outlet />,
         children: [
-          // 기본 경로는 나의 이슈 페이지로 리다이렉트되게 했음. (문제시 변경)
-          { index: true, element: <Navigate to="myissue" replace /> },
-          { path: 'noti', element: <div>{/* Notification 페이지 */}</div> },
-          { path: 'myissue', element: <div>{/* MyIssue_Home 페이지 */}</div> },
-          { path: 'myissue/:myIssueId', element: <div>{/* MyIssue_Detail 페이지 */}</div> },
-          { path: 'mygoal', element: <div>{/* MyGoal_Home 페이지 */}</div> },
-          { path: 'mygoal/:mygGoalId', element: <div>{/* MyGoal_Detail 페이지 */}</div> },
-          { path: 'setting', element: <div>{/* Setting 페이지 */}</div> },
+          // 기본 경로는 워크스페이스 프로필 페이지로 리다이렉트.
+          { index: true, element: <Navigate to="ws-profile" replace /> },
+          { path: 'ws-profile', element: <div>Setting_Workspace_Profile</div> },
+          { path: 'team-list', element: <div>Setting_Team_List</div> },
+          { path: 'team-list/ws', element: <div>Setting_Workspace_Member_List</div> },
+          { path: 'team-list/:teamId', element: <div>Setting_Team_Member_List</div> },
+          { path: 'my-profile', element: <div>Setting_My_Profile</div> },
         ],
       },
+      /* 워크스페이스 전체 팀 페이지들 */
+      {
+        path: 'team/default',
+        element: <Outlet />,
+        children: [
+          // 기본 경로는 이슈 페이지로 리다이렉트
+          { index: true, element: <Navigate to="issue" replace /> },
+          { path: 'issue', element: <div>Workspace_Issue_Home</div> },
+          { path: 'issue/:issueId', element: <div>Workspace_Issue_Detail</div> },
+          { path: 'goal', element: <div>Workspace_Goal_Home</div> },
+          { path: 'goal/:goalId', element: <div>Workspace_Goal_Detail</div> },
+          { path: 'ext', element: <div>Workspace_External_Home</div> },
+          { path: 'ext/:extId', element: <div>Workspace_External_Detail</div> },
+        ],
+      },
+      /* 팀별 페이지들 */
       {
         path: 'team/:teamId',
-        element: <Outlet />, // Placeholder (필요시 컴포넌트로 변경하여 작성 후 연결)
+        element: <Outlet />,
         children: [
           // 기본 경로는 이슈 페이지로 리다이렉트.
           { index: true, element: <Navigate to="issue" replace /> },
           { path: 'goal', element: <GoalHome /> },
-          { path: 'goal/:goalId', element: <div>{/* Goal_Detail 페이지 */}</div> },
+          { path: 'goal/:goalId', element: <div>Goal_Detail</div> },
           { path: 'issue', element: <IssueHome /> },
-          { path: 'issue/:issueId', element: <div>{/* Issue_Detail 페이지 */}</div> },
-          { path: 'ext', element: <div>{/* External_Home 페이지 */}</div> },
-          { path: 'ext/:extId', element: <div>{/* External_Detail 페이지 */}</div> },
-          { path: 'doc', element: <div>{/* Document_Home 페이지 */}</div> },
-          { path: 'doc/:docId', element: <div>{/* Document_Detail 페이지 */}</div> },
+          { path: 'issue/:issueId', element: <div>Issue_Detail</div> },
+          { path: 'ext', element: <div>External_Home</div> },
+          { path: 'ext/:extId', element: <div>External_Detail</div> },
         ],
       },
     ],

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -9,18 +9,23 @@ import OnboardingFinish from '../pages/onboarding/OnboardingFinish';
 export const publicRoutes: RouteObject[] = [
   {
     path: '/',
-    element: <AuthRedirect />,
+    element: <div>HomeLayout</div>,
     errorElement: <div>Not Found</div>,
+    children: [
+      // 도메인 최상위: 백호 랜딩페이지
+      { index: true, element: <div>VECO Landing Page</div> },
+      // '시작하기'를 눌렀을 때 AuthRedirect 컴포넌트로 리다이렉트.
+      // 사용자 인증 여부에 따라 protected 또는 public 경로로 리다이렉트됨.
+      { path: 'entry', element: <AuthRedirect /> },
+      // 모든 잘못된 경로는 Not Found로 처리
+      { path: '*', element: <div>Not Found</div> },
+    ],
   },
   {
+    // Onboarding 단계 페이지들
     path: '/onboarding',
-    element: <PublicLayout />, // Placeholder (필요시 OnboardingLayout 작성 후 연결)
+    element: <PublicLayout />,
     errorElement: <div>Not Found</div>,
-
-    /*
-      하위 경로 페이지들: 전부 placeholder 처리해둠.
-      필요시 각 페이지 파일 작성 후 연결하여 사용.
-    */
     children: [
       {
         index: true,
@@ -53,6 +58,14 @@ export const publicRoutes: RouteObject[] = [
             <OnboardingFinish />
           </div>
         ),
+      },
+      {
+        path: 'input-pw',
+        element: <div>Participate_Workspace_Input_PW</div>,
+      },
+      {
+        path: '*',
+        element: <div>Not Found</div>, // 모든 잘못된 경로는 Not Found로 처리.
       },
     ],
   },

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -17,12 +17,10 @@ export const publicRoutes: RouteObject[] = [
       // '시작하기'를 눌렀을 때 AuthRedirect 컴포넌트로 리다이렉트.
       // 사용자 인증 여부에 따라 protected 또는 public 경로로 리다이렉트됨.
       { path: 'entry', element: <AuthRedirect /> },
-      // 모든 잘못된 경로는 Not Found로 처리
-      { path: '*', element: <div>Not Found</div> },
     ],
   },
+  /* Onboarding 단계 페이지들 */
   {
-    // Onboarding 단계 페이지들
     path: '/onboarding',
     element: <PublicLayout />,
     errorElement: <div>Not Found</div>,
@@ -62,10 +60,6 @@ export const publicRoutes: RouteObject[] = [
       {
         path: 'input-pw',
         element: <div>Participate_Workspace_Input_PW</div>,
-      },
-      {
-        path: '*',
-        element: <div>Not Found</div>, // 모든 잘못된 경로는 Not Found로 처리.
       },
     ],
   },

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,0 @@
-// src/routers/index.ts
-import { createBrowserRouter } from 'react-router-dom';
-import { publicRoutes } from './PublicRoutes';
-import { protectedRoutes } from './ProtectedRoutes';
-
-const router = createBrowserRouter([...publicRoutes, ...protectedRoutes]);
-
-export default router;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,12 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { publicRoutes } from './PublicRoutes';
+import { protectedRoutes } from './ProtectedRoutes';
+
+const router = createBrowserRouter([
+  ...publicRoutes,
+  ...protectedRoutes,
+  // 모든 잘못된 경로는 Not Found로 처리
+  { path: '*', element: <div>Not Found</div> },
+]);
+
+export default router;


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- #50 

---

### ✅ Key Changes

- 추가/삭제된 페이지들의 라우팅을 노션 db에 반영 [노션 링크](https://www.notion.so/2222d37cca1180c8850cdb8f09e27a57)
- `src/routes` 폴더의 `publicRoutes.tsx`, `protectedRoutes.tsx` 내에 변경된 페이지 라우팅 반영
- `src/routes/index.tsx`에 잘못 매칭된 경로를 `Not Found Page`로 보내는 코드 추가

---

### 📸 스크린샷 or 실행영상
페이지 라우팅 수정이므로 별도로 스크린샷을 첨부하지 않았습니다.

---

### 💬 To Reviewers

1. 백호 랜딩페이지가 도메인 최상위 경로가 될 것을 고려해 코드상에 반영해두었습니다.

2. 워크스페이스 내부 페이지들은 base path를 모두 `'/workspace'`로 해두었습니다.

3. 404 Not Found 페이지 처리
해당 404 페이지는 크게 아래 경우에 대해 뜨게 되는 페이지입니다.
(1) 렌더 에러 발생 시 : 이 경우 `protectRoutes.tsx`와 `publicRoutes.tsx`의 `errorElement`로 처리했습니다.
(2) 사용자가 url에 잘못된 경로를 입력하여, 매칭할 경로가 없을 시 : 이 경우 `index.tsx`에 아래와 같은 코드를 추가했습니다.
```
const router = createBrowserRouter([
  ...publicRoutes,
  ...protectedRoutes,
  // 모든 잘못된 경로는 Not Found로 처리
  { path: '*', element: <div>Not Found</div> },
]);
```
각 Not Found가 들어가야할 부분에 대해 Placeholder 처리를 해두었습니다. 해당 404 페이지 작업 완료 후에, 실제 컴포넌트를 넣어주세요~~! @waldls 
