### PR TITLE
[UI] 목표 상세페이지 구현

### DIFF
--- a/src/components/DetailView/Comment/CommentInput.tsx
+++ b/src/components/DetailView/Comment/CommentInput.tsx
@@ -31,6 +31,8 @@ const CommentInput = ({ onAdd }: CommentIntputProps) => {
     >
       {/* 댓글 입력창 영역 */}
       <textarea
+        name="commentInput"
+        id="commentInput"
         value={comment}
         onChange={handleChange}
         placeholder="댓글을 작성하세요."

--- a/src/components/DetailView/Comment/CommentInput.tsx
+++ b/src/components/DetailView/Comment/CommentInput.tsx
@@ -24,7 +24,7 @@ const CommentInput = ({ onAdd }: CommentIntputProps) => {
 
   return (
     <div
-      className="flex flex-end items-end gap-[0.8rem] w-full h-[13rem] p-[2.4rem] bg-gray-100 rounded-lg"
+      className="absolute bottom-0 z-20 w-full flex items-end gap-[0.8rem] h-[13rem] p-[2.4rem] bg-gray-100 rounded-lg"
       style={{
         boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.10), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
       }}

--- a/src/components/DetailView/Comment/CommentItem.tsx
+++ b/src/components/DetailView/Comment/CommentItem.tsx
@@ -19,9 +19,9 @@ const CommentItem = ({ author, content, createAt }: CommentItemProps) => {
         {/* 작성자 정보 */}
         <div className="flex items-center gap-[0.8rem]">
           {/* 작성자 이름 */}
-          <span className="font-body-b text-gray-600">{author}</span>
+          <span className="font-body-b text-gray-600 truncate">{author}</span>
           {/* 작성 시간 */}
-          <span className="font-small-r text-gray-500">{createAt.toLocaleString()}</span>
+          <span className="font-small-r text-gray-500 truncate">{createAt.toLocaleString()}</span>
         </div>
 
         {/* 댓글 내용 */}

--- a/src/components/DetailView/Comment/CommentItem.tsx
+++ b/src/components/DetailView/Comment/CommentItem.tsx
@@ -17,7 +17,7 @@ const CommentItem = ({ author, content, createAt }: CommentItemProps) => {
 
       <div className="flex flex-col gap-[0.8rem]">
         {/* 작성자 정보 */}
-        <div className="flex gap-[0.8rem]">
+        <div className="flex items-center gap-[0.8rem]">
           {/* 작성자 이름 */}
           <span className="font-body-b text-gray-600">{author}</span>
           {/* 작성 시간 */}

--- a/src/components/DetailView/Comment/CommentSection.tsx
+++ b/src/components/DetailView/Comment/CommentSection.tsx
@@ -40,15 +40,21 @@ const CommentSection = () => {
             <div className="font-body-r text-gray-600">댓글을 작성하세요.</div>
           </div>
         ) : (
-          // 댓글이 있을 때: 댓글 목록을 렌더링
+          // 댓글이 있을 때: 댓글 목록 렌더링
           <>
             <div className="absolute bottom-[14.6rem] w-full z-10 pr-[1.2rem]">
               {/* 댓글 목록 위에 옅은 흰색 그라디언트 처리 */}
               <div className="w-full h-[6.4rem] bg-gradient-to-b from-white/0 to-white pointer-events-none" />
             </div>
+            {/* 댓글을 순서대로 목록에 추가 */}
             <div className="flex flex-col gap-y-[2.4rem] mb-[14.6rem] w-full overflow-y-scroll basic-scroll">
               {comments.map(({ author, content, createAt }) => (
-                <CommentItem author={author} content={content} createAt={createAt} />
+                <CommentItem
+                  key={`${createAt.getTime()}-${author}`} // Date를 밀리초 숫자로 변환
+                  author={author}
+                  content={content}
+                  createAt={createAt}
+                />
               ))}
             </div>
           </>

--- a/src/components/DetailView/Comment/CommentSection.tsx
+++ b/src/components/DetailView/Comment/CommentSection.tsx
@@ -24,7 +24,7 @@ const CommentSection = () => {
   };
 
   return (
-    <div className="flex flex-col gap-[3.2rem] w-full h-[41rem]">
+    <div className="flex flex-col gap-[3.2rem] w-full">
       {/* 댓글 목록 헤더 */}
       <div className="flex gap-[0.8rem]">
         <div className="font-title-sub-r text-gray-600">댓글</div>

--- a/src/components/DetailView/Comment/CommentSection.tsx
+++ b/src/components/DetailView/Comment/CommentSection.tsx
@@ -41,16 +41,22 @@ const CommentSection = () => {
           </div>
         ) : (
           // 댓글이 있을 때: 댓글 목록을 렌더링
-          <div className="flex flex-col gap-y-[2.4rem] mb-[13rem] w-full overflow-scroll basic-scroll">
-            {comments.map(({ author, content, createAt }) => (
-              <CommentItem author={author} content={content} createAt={createAt} />
-            ))}
-          </div>
+          <>
+            <div className="absolute bottom-[14.6rem] w-full z-10 pr-[1.2rem]">
+              {/* 댓글 목록 위에 옅은 흰색 그라디언트 처리 */}
+              <div className="w-full h-[6.4rem] bg-gradient-to-b from-white/0 to-white pointer-events-none" />
+            </div>
+            <div className="flex flex-col gap-y-[2.4rem] mb-[14.6rem] w-full overflow-y-scroll basic-scroll">
+              {comments.map(({ author, content, createAt }) => (
+                <CommentItem author={author} content={content} createAt={createAt} />
+              ))}
+            </div>
+          </>
         )}
-
-        {/* 댓글 입력창 */}
-        <CommentInput onAdd={handleAddComment} />
       </div>
+
+      {/* 댓글 입력창 */}
+      <CommentInput onAdd={handleAddComment} />
     </div>
   );
 };

--- a/src/components/DetailView/Comment/CommentSection.tsx
+++ b/src/components/DetailView/Comment/CommentSection.tsx
@@ -24,7 +24,7 @@ const CommentSection = () => {
   };
 
   return (
-    <div className="flex flex-col gap-[3.2rem] w-full">
+    <div className="relative flex flex-col flex-1 gap-[3.2rem] w-full min-h-0">
       {/* 댓글 목록 헤더 */}
       <div className="flex gap-[0.8rem]">
         <div className="font-title-sub-r text-gray-600">댓글</div>
@@ -32,20 +32,21 @@ const CommentSection = () => {
         <div className="font-title-sub-r text-gray-500">{comments.length}</div>
       </div>
 
-      <div className="flex flex-col gap-[1.6rem] w-full h-[35rem]">
+      <div className="flex flex-col w-full max-h-full overflow-y-auto basic-scroll">
         {/* 댓글 목록 */}
-        <div className="flex flex-col gap-[2.4rem] w-full h-full overflow-y-auto basic-scroll">
-          {comments.length === 0 ? (
-            <div className="flex items-center justify-center w-full h-full">
-              {/* 댓글 개수가 0개일 때: 댓글 목록의 초기 문구를 띄우도록 */}
-              <div className="font-body-r text-gray-600">댓글을 작성하세요.</div>
-            </div>
-          ) : (
-            comments.map(({ author, content, createAt }) => (
+        {comments.length === 0 ? (
+          // 댓글 개수가 0개일 때: 댓글 목록의 초기 문구를 띄우도록
+          <div className="flex items-center justify-center w-full">
+            <div className="font-body-r text-gray-600">댓글을 작성하세요.</div>
+          </div>
+        ) : (
+          // 댓글이 있을 때: 댓글 목록을 렌더링
+          <div className="flex flex-col gap-y-[2.4rem] mb-[13rem] w-full overflow-scroll basic-scroll">
+            {comments.map(({ author, content, createAt }) => (
               <CommentItem author={author} content={content} createAt={createAt} />
-            ))
-          )}
-        </div>
+            ))}
+          </div>
+        )}
 
         {/* 댓글 입력창 */}
         <CommentInput onAdd={handleAddComment} />

--- a/src/components/DetailView/CompletionButton.tsx
+++ b/src/components/DetailView/CompletionButton.tsx
@@ -26,7 +26,7 @@ const CompletionButton = ({ isTitleFilled, isCompleted, onToggle }: CompletionBu
   const textColor = isDisabled ? 'text-gray-400' : 'text-gray-100';
 
   return (
-    <div className="flex items-end justify-end">
+    <div className="flex items-end justify-end fixed bottom-[5.3rem] right-[6.4rem] z-20">
       <button
         onClick={isDisabled ? undefined : onToggle}
         disabled={isDisabled}

--- a/src/components/DetailView/DetailTextEditor.tsx
+++ b/src/components/DetailView/DetailTextEditor.tsx
@@ -14,7 +14,7 @@ const DetailTextEditor = ({ isEditable }: DetailTextEditorProps) => {
   return (
     <textarea
       disabled={!isEditable}
-      className="w-full h-full font-body-r placeholder-gray-400 text-gray-600 overflow-y-scroll basic-scroll resize-none focus:outline-none pr-4 ${!isEditable ? 'cursor-not-allowed text-gray-600' : ''}"
+      className="w-full flex-1 font-body-r placeholder-gray-400 text-gray-600 overflow-y-scroll basic-scroll resize-none focus:outline-none pr-4 ${!isEditable ? 'cursor-not-allowed text-gray-600' : ''}"
       placeholder="상세 설명 추가"
     ></textarea>
   );

--- a/src/components/DetailView/DetailTextEditor.tsx
+++ b/src/components/DetailView/DetailTextEditor.tsx
@@ -13,6 +13,8 @@ interface DetailTextEditorProps {
 const DetailTextEditor = ({ isEditable }: DetailTextEditorProps) => {
   return (
     <textarea
+      name="detailTextEditor"
+      id="detailTextEditor"
       disabled={!isEditable}
       className="w-full flex-1 font-body-r placeholder-gray-400 text-gray-600 overflow-y-scroll basic-scroll resize-none focus:outline-none pr-4 ${!isEditable ? 'cursor-not-allowed text-gray-600' : ''}"
       placeholder="상세 설명 추가"

--- a/src/components/DetailView/DetailTitle.tsx
+++ b/src/components/DetailView/DetailTitle.tsx
@@ -46,6 +46,12 @@ const DetailTitle = ({ defaultTitle, title, setTitle, isEditable }: DetailTitleP
       value={title}
       rows={1}
       onChange={handleChange}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault(); // ✅ 줄바꿈 막기
+          console.log('Enter blocked');
+        }
+      }}
       disabled={!isEditable}
       // 각 페이지별 placeholder를 서로 다르게 할 수 있도록 defaultTitle로 처리
       placeholder={defaultTitle}

--- a/src/components/DetailView/DetailTitle.tsx
+++ b/src/components/DetailView/DetailTitle.tsx
@@ -42,6 +42,8 @@ const DetailTitle = ({ defaultTitle, title, setTitle, isEditable }: DetailTitleP
 
   return (
     <textarea
+      name="detailTitle"
+      id="detailTitle"
       ref={textarea}
       value={title}
       rows={1}

--- a/src/components/DetailView/DetailTitle.tsx
+++ b/src/components/DetailView/DetailTitle.tsx
@@ -48,8 +48,7 @@ const DetailTitle = ({ defaultTitle, title, setTitle, isEditable }: DetailTitleP
       onChange={handleChange}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
-          e.preventDefault(); // ✅ 줄바꿈 막기
-          console.log('Enter blocked');
+          e.preventDefault(); // 엔터 키를 눌러 직접 줄바꿈하는 것 방지
         }
       }}
       disabled={!isEditable}

--- a/src/components/DetailView/PropertyItem.tsx
+++ b/src/components/DetailView/PropertyItem.tsx
@@ -2,9 +2,6 @@
  * PropertyItem.tsx
  * 상세페이지 내 속성 항목 컴포넌트
  *
- * @todo
- * - 화면 가로 길이 줄여도 줄어들지 않게 처리
- *
  * @description
  * - 속성 항목 수정은 상세페이지 내의 작성 완료 버튼 클릭 여부에 영향을 받지 않도록 구현.
  *   (즉, 속성은 언제나 수정 가능함)
@@ -37,7 +34,8 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
 
   return (
     <div
-      className={`flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200`}
+      onClick={() => setIsOpen(!isOpen)}
+      className={`flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer`}
     >
       {/* 속성 아이콘 */}
       {getColor ? (
@@ -54,13 +52,13 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
       )}
 
       {/* 속성 이름 */}
-      <div className={`flex relative cursor-pointer`}>
-        <span className="flex items-center" onClick={() => setIsOpen(!isOpen)}>
+      <div className={`flex relative`}>
+        <span className="flex items-center">
           {/* 속성 항목명 */}
           <div className="font-body-r text-gray-600">{value}</div>
         </span>
 
-        {/* 속성 항목명을 눌러 드롭다운 오픈 */}
+        {/* 드롭다운 오픈 */}
         {isOpen && (
           <Dropdown
             value={value}

--- a/src/components/DetailView/PropertyItem.tsx
+++ b/src/components/DetailView/PropertyItem.tsx
@@ -56,10 +56,8 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
 
       {/* 속성 이름 */}
       <div className={`flex relative`}>
-        <div className="flex items-center">
-          {/* 속성 항목명 */}
-          <div className="font-body-r text-gray-600">{value}</div>
-        </div>
+        {/* 속성 항목명 */}
+        <p className="font-body-r text-gray-600 max-w-[27.4rem] truncate">{value}</p>
 
         {/* 드롭다운 오픈 */}
         {isOpen && (

--- a/src/components/DetailView/PropertyItem.tsx
+++ b/src/components/DetailView/PropertyItem.tsx
@@ -5,7 +5,10 @@
  * @description
  * - 속성 항목 수정은 상세페이지 내의 작성 완료 버튼 클릭 여부에 영향을 받지 않도록 구현.
  *   (즉, 속성은 언제나 수정 가능함)
- * - 기한 드롭다운은 이 컴포넌트로 관리하지 않음 (별도로 필요한 상세페이지에서 구현)
+ *
+ * @todo
+ * - 현재는 '기한' 속성과 '이슈' 속성의 드롭다운은 이 컴포넌트에서 관리하지 않음.
+ * - 추후 더 나은 컴포넌트 연결 방식 고민해보고 리팩토링 예정.
  */
 
 import { useState } from 'react';
@@ -23,8 +26,8 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
   const initialValue = defaultValue && iconMap && iconMap[defaultValue] ? defaultValue : options[0];
 
   const [value, setValue] = useState(defaultValue);
-  const [isOpen, setIsOpen] = useState(false);
   const [icon, setIcon] = useState(iconMap ? iconMap[initialValue] : undefined);
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleSelect = (option: string) => {
     setValue(option);
@@ -53,10 +56,10 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
 
       {/* 속성 이름 */}
       <div className={`flex relative`}>
-        <span className="flex items-center">
+        <div className="flex items-center">
           {/* 속성 항목명 */}
           <div className="font-body-r text-gray-600">{value}</div>
-        </span>
+        </div>
 
         {/* 드롭다운 오픈 */}
         {isOpen && (

--- a/src/components/Dropdown/ArrowDropdown.tsx
+++ b/src/components/Dropdown/ArrowDropdown.tsx
@@ -33,6 +33,7 @@ const ArrowDropdown = ({
       style={{ boxShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.15)' }}
       className={`absolute z-30 top-0 left-0 flex flex-col w-[27.4rem]
       border border-gray-400 bg-white rounded-[0.4rem] ${className}`}
+      onClick={(e) => e.stopPropagation()}
     >
       <div
         className={`flex border-b border-gray-200 justify-between items-center py-[0.4rem] ps-[1.2rem] pe-[0.8rem]`}

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -15,7 +15,7 @@ import pr3 from '../../assets/icons/pr-3-sm.svg';
 import pr4 from '../../assets/icons/pr-4-sm.svg';
 import IcProfile from '../../assets/icons/user-circle-sm.svg';
 import IcCalendar from '../../assets/icons/date-lg.svg';
-// import IcIssue from '../../assets/icons/issue.svg';
+import IcIssue from '../../assets/icons/issue.svg';
 
 import { getStatusColor } from '../../utils/listItemUtils';
 import { statusLabelToCode } from '../../types/detailitem';
@@ -23,6 +23,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 
 const GoalDetail = () => {
   const [title, setTitle] = useState('');
@@ -31,9 +32,9 @@ const GoalDetail = () => {
   // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
 
-  // 달력 드롭다운 열림/닫힘 관리
+  const [option, setOption] = useState<string>('이슈');
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
-  const { openDropdown } = useDropdownActions();
+  const { openDropdown, closeDropdown } = useDropdownActions();
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -138,12 +139,11 @@ const GoalDetail = () => {
               >
                 {/* '기한' 속성 아이콘 */}
                 <img src={IcCalendar} alt="date" />
-
-                {/* 항목명 */}
                 <div className="relative">
+                  {/* '기한' 항목명 - 날짜 설정하면 반영됨 */}
                   <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
-
-                  {isOpen && content && (
+                  {/* 달력 드롭다운 오픈 */}
+                  {isOpen && content?.name === 'date' && (
                     <CalendarDropdown
                       selectedDate={selectedDate}
                       onSelect={(date) => setSelectedDate(date)}
@@ -153,13 +153,37 @@ const GoalDetail = () => {
               </div>
 
               {/* (5) 이슈 */}
-              <div onClick={(e) => e.stopPropagation()}>
-                {/*
-                  <PropertyItem
-                    defaultValue="이슈"
-                    iconMap={{ 이슈: issueIconMap }}
-                  />
-                */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: '이슈' });
+                }}
+                className={`flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer`}
+              >
+                {/* 속성 아이콘 */}
+                <img src={IcIssue} alt="이슈" />
+
+                {/* 속성 이름 */}
+                <div className="flex relative">
+                  <div className="flex items-center">
+                    {/* 속성 항목명 */}
+                    <div className="font-body-r text-gray-600">{option}</div>
+                  </div>
+
+                  {/* 드롭다운 오픈 */}
+                  {isOpen && content?.name === '이슈' && (
+                    <ArrowDropdown
+                      defaultValue={'이슈'}
+                      options={[
+                        '기능 정의: 구현할 핵심 기능과 어쩌구 저쩌구 텍스트가 길어지면 이렇게 표시',
+                        '와이어프레임 디자인',
+                        '컴포넌트 정리',
+                      ]}
+                      onSelect={(value: string) => setOption(value)}
+                      onClose={closeDropdown}
+                    />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -14,16 +14,34 @@ import pr2 from '../../assets/icons/pr-2-sm.svg';
 import pr3 from '../../assets/icons/pr-3-sm.svg';
 import pr4 from '../../assets/icons/pr-4-sm.svg';
 import IcProfile from '../../assets/icons/user-circle-sm.svg';
-// import IcDate from '../../assets/icons/date-lg.svg';
+import IcCalendar from '../../assets/icons/date-lg.svg';
 // import IcIssue from '../../assets/icons/issue.svg';
 
 import { getStatusColor } from '../../utils/listItemUtils';
 import { statusLabelToCode } from '../../types/detailitem';
 import CommentSection from '../../components/DetailView/Comment/CommentSection';
+import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
+import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
+import { formatDateDot } from '../../utils/formatDate';
 
 const GoalDetail = () => {
   const [title, setTitle] = useState('');
   const [isCompleted, setIsCompleted] = useState(false);
+
+  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+
+  // 달력 드롭다운 열림/닫힘 관리
+  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
+  const { openDropdown } = useDropdownActions();
+
+  // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
+  const getDisplayText = () => {
+    const [start, end] = selectedDate;
+    if (start && end) return `${formatDateDot(start)} - ${formatDateDot(end)}`; // 시작일과 종료일 둘 다 있을 경우
+    if (start || end) return formatDateDot(start ?? end!); // 날짜 하나만 선택된 경우
+    return '기한'; // 날짜 선택 안 된 경우: default로 '기한' 글씨가 그대로 보이도록
+  };
 
   // '우선순위' 속성 아이콘 매핑
   const priorityIconMap = {
@@ -111,19 +129,38 @@ const GoalDetail = () => {
               </div>
 
               {/* (4) 기한 */}
-              {/* <PropertyItem defaultValue="기한" iconMap={{ 기한: dateIconMap }} /> */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: 'date' });
+                }}
+                className="flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer"
+              >
+                {/* '기한' 속성 아이콘 */}
+                <img src={IcCalendar} alt="date" />
+
+                {/* 항목명 */}
+                <div className="relative">
+                  <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
+
+                  {isOpen && content && (
+                    <CalendarDropdown
+                      selectedDate={selectedDate}
+                      onSelect={(date) => setSelectedDate(date)}
+                    />
+                  )}
+                </div>
+              </div>
 
               {/* (5) 이슈 */}
-              {/**
-               * @todo
-               * - 이슈 많아질 경우 '외 n개'로 축약되게 하기
-               */}
-              {/*
-                <PropertyItem
-                  defaultValue="이슈"
-                  iconMap={{ 이슈: issueIconMap }}
-                />
-              */}
+              <div onClick={(e) => e.stopPropagation()}>
+                {/*
+                  <PropertyItem
+                    defaultValue="이슈"
+                    iconMap={{ 이슈: issueIconMap }}
+                  />
+                */}
+              </div>
             </div>
           </div>
 

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -77,7 +77,7 @@ const GoalDetail = () => {
       {/* 상세페이지 메인 */}
       <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)]">
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="목표를 생성하세요"

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -165,10 +165,8 @@ const GoalDetail = () => {
 
                 {/* 속성 이름 */}
                 <div className="flex relative">
-                  <div className="flex items-center">
-                    {/* 속성 항목명 */}
-                    <div className="font-body-r text-gray-600">{option}</div>
-                  </div>
+                  {/* 속성 항목명 */}
+                  <p className="font-body-r text-gray-600 max-w-[27.4rem] truncate">{option}</p>
 
                   {/* 드롭다운 오픈 */}
                   {isOpen && content?.name === '이슈' && (

--- a/src/pages/goal/GoalHome.tsx
+++ b/src/pages/goal/GoalHome.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../types/testDummy';
 import type { GoalFilter, GroupedGoal } from '../../types/goal';
 import { getSortedGrouped } from '../../utils/listGroupSortUtils';
+import { useNavigate } from 'react-router-dom';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자'] as const;
 
@@ -23,6 +24,11 @@ const GoalHome = () => {
   const { isOpen, content } = useDropdownInfo();
   const { openDropdown, closeDropdown } = useDropdownActions();
   const [filter, setFilter] = useState<ItemFilter>('상태');
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(':goalId');
+  };
 
   // filter 변경마다 다른 데이터 선택 -> 추후 새로운 데이터 불러오도록
   const dummyGoalGroups = useMemo<GoalFilter[]>(() => {
@@ -122,8 +128,13 @@ const GoalHome = () => {
                       </div>
                       <div className="text-gray-500 ml-[0.8rem]">{items.length}</div>
                     </div>
-                    {/* TODO : 추가 버튼 라우터 연결 */}
-                    <img src={PlusIcon} className="inline-block w-[2.4rem] h-[2.4rem]" alt="" />
+                    {/* 추가 버튼 */}
+                    <img
+                      src={PlusIcon}
+                      className="inline-block w-[2.4rem] h-[2.4rem]"
+                      alt=""
+                      onClick={handleClick}
+                    />
                   </div>
                   {/* 각 유형 별 요소 */}
                   {items.map((goal) => (

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -5,8 +5,8 @@ export const formatDate = (date: Date) => {
 };
 
 export const formatDateDot = (date: Date): string => {
-  const yyyy = date.getFullYear();
+  const yy = date.getFullYear().toString().slice(-2); // 연도 뒤 2자리만 사용
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}.${mm}.${dd}`;
+  return `${yy}.${mm}.${dd}`;
 };


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #57 

---

### ✅ Key Changes
구현한 상세페이지 기본 컴포넌트 기반으로, 목표 상세페이지 구현을 완료했습니다.

주요 변경사항:
- 달력 드롭다운(`CalendarDropdown.tsx`)을 '기한' 속성 항목에 연결 완료.
- 이슈 드롭다운(`ArrowDropdown.tsx`)을 '이슈' 속성 항목에 연결 완료.
- '속성' 탭에서 각 속성별로 클릭 가능한 범위: 속성 항목명에서 속성 아이템(`PropertyItem.tsx`)으로 변경하여 UX 개선.

**⚠️ 25.07.31. update 내용:**
- pr 남겨주신 내용 반영하여, '기한' 속성의 항목명 서식을 바꾸었습니다 (연도 숫자 끝 2자리만 뜨도록)
- pr 남겨주신 내용 반영하여, 상세 설명 영역과 댓글창 영역 둘다 확보하되, 댓글목록에 고정 높이를 지정하지 않고 스크롤뷰 구현을 했습니다.
- 상세페이지 제목 줄바꿈: 엔터 키 눌러서 줄바꿈 되는 것을 방지했습니다.

---

### 📸 스크린샷 or 실행영상


https://github.com/user-attachments/assets/b8afe330-4448-4924-b382-24bf5e038e33



---

### 💬 To Reviewers

~~**상세페이지 타이틀 문구가 파묻히는 문제**~~
- ~~상세페이지 제목 입력하여 작성 완료 버튼을 눌렀을 때 댓글창은 제대로 나타나지만, 상세페이지 제목이 파묻히게 되는 현상~~
=> ✅ 금주에 리팩토링하면서 해당 오류를 수정하였습니다.

~~**기타: 디자인 측에게 추가 기능 명세 물어보고 반영해야 하는 부분들**~~
- ~~금주에 논의 완료 후 추가 반영하겠습니다.~~
=> ✅ 금주에 논의 완료된 내용(댓글창 위 오버레이되는 흰색 그라데이션)을 반영했습니다.

**이슈 드롭다운(`ArrowDropdown.tsx`) 관련 요청** @gaeulzzang 
- (1) 현재 실행 영상을 보시면, '이슈' 속성의 드롭다운에서 개별 항목을 선택해도 해당 드롭다운이 닫히지 않습니다. 코드상에는 항목 선택 시 드롭다운이 닫히게 하는 로직이 반영되어있는 것 같은데 왜 안되는지 모르겠습니다 🥲
- (2) 이슈 드롭다운 내 항목 중 텍스트가 길어서 넘치는 항목을 선택했을 때, 해당 드롭다운을 사용한 부모 컴포넌트에 보여지는 항목명도 truncate 속성이 적용되어 "..." 처리되게 하려면 어떻게 해야 하나요? truncate 속성을 썼는데 잘 안되네요.

**그외 자잘한 내용들을 마저 수정하였습니다.**
**확인 후 리뷰 부탁드립니다.** @sunhwaaRj @jinj00oo @waldls 