### PR TITLE
[UI] 이슈 상세페이지 구현

### DIFF
--- a/src/components/DetailView/PropertyItem.tsx
+++ b/src/components/DetailView/PropertyItem.tsx
@@ -7,7 +7,7 @@
  *   (즉, 속성은 언제나 수정 가능함)
  *
  * @todo
- * - 현재는 '기한' 속성과 '이슈' 속성의 드롭다운은 이 컴포넌트에서 관리하지 않음.
+ * - 현재는 '기한' 속성과 '이슈', '목표' 속성의 드롭다운은 이 컴포넌트에서 관리하지 않음.
  * - 추후 더 나은 컴포넌트 연결 방식 고민해보고 리팩토링 예정.
  */
 
@@ -58,7 +58,7 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
       <div className={`flex relative`}>
         <div className="flex items-center">
           {/* 속성 항목명 */}
-          <div className="font-body-r text-gray-600">{value}</div>
+          <div className="font-body-r text-gray-600 truncate">{value}</div>
         </div>
 
         {/* 드롭다운 오픈 */}

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -1,0 +1,5 @@
+const IssueDetail = () => {
+  return <div></div>;
+};
+
+export default IssueDetail;

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -24,7 +24,7 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 
-const GoalDetail = () => {
+const IssueDetail = () => {
   const [title, setTitle] = useState('');
   const [isCompleted, setIsCompleted] = useState(false);
 
@@ -181,4 +181,4 @@ const GoalDetail = () => {
   );
 };
 
-export default GoalDetail;
+export default IssueDetail;

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -1,5 +1,184 @@
-const IssueDetail = () => {
-  return <div></div>;
+// IssueDetail.tsx
+// 이슈 상세페이지
+
+import { useState } from 'react';
+import DetailHeader from '../../components/DetailView/DetailHeader';
+import PropertyItem from '../../components/DetailView/PropertyItem';
+import DetailTitle from '../../components/DetailView/DetailTitle';
+import CompletionButton from '../../components/DetailView/CompletionButton';
+import DetailTextEditor from '../../components/DetailView/DetailTextEditor';
+
+// 속성 항목별 아이콘 svg import
+import pr1 from '../../assets/icons/pr-1-sm.svg';
+import pr2 from '../../assets/icons/pr-2-sm.svg';
+import pr3 from '../../assets/icons/pr-3-sm.svg';
+import pr4 from '../../assets/icons/pr-4-sm.svg';
+import IcProfile from '../../assets/icons/user-circle-sm.svg';
+import IcCalendar from '../../assets/icons/date-lg.svg';
+import IcGoal from '../../assets/icons/goal.svg';
+
+import { getStatusColor } from '../../utils/listItemUtils';
+import { statusLabelToCode } from '../../types/detailitem';
+import CommentSection from '../../components/DetailView/Comment/CommentSection';
+import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
+import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
+import { formatDateDot } from '../../utils/formatDate';
+
+const GoalDetail = () => {
+  const [title, setTitle] = useState('');
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+
+  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
+  const { openDropdown } = useDropdownActions();
+
+  // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
+  const getDisplayText = () => {
+    const [start, end] = selectedDate;
+    if (start && end) return `${formatDateDot(start)} - ${formatDateDot(end)}`; // 시작일과 종료일 둘 다 있을 경우
+    if (start || end) return formatDateDot(start ?? end!); // 날짜 하나만 선택된 경우
+    return '기한'; // 날짜 선택 안 된 경우: default로 '기한' 글씨가 그대로 보이도록
+  };
+
+  // '우선순위' 속성 아이콘 매핑
+  const priorityIconMap = {
+    우선순위: pr3,
+    없음: pr3,
+    낮음: pr1,
+    중간: pr2,
+    높음: pr3,
+    긴급: pr4,
+  };
+
+  // '담당자' 속성 아이콘 매핑 (나중에 API로부터 받아온 데이터로 대체 예정)
+  const userIconMap = {
+    담당자: IcProfile,
+    없음: IcProfile,
+    전채운: IcProfile,
+    전시현: IcProfile,
+  };
+
+  const goalIconMap = {
+    목표: IcGoal,
+    없음: IcGoal,
+    '백호를 사용해서 다른 사람들과 협업해보기': IcGoal,
+    '기획 및 요구사항 분석': IcGoal,
+  };
+
+  const handleToggle = () => {
+    setIsCompleted((prev) => !prev);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
+      {/* 상세페이지 헤더 */}
+      <DetailHeader defaultTitle="이슈를 생성하세요" title={title} />
+
+      {/* 상세페이지 메인 */}
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
+        {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
+          {/* 상세페이지 제목 */}
+          <DetailTitle
+            defaultTitle="이슈를 생성하세요"
+            title={title}
+            setTitle={setTitle}
+            isEditable={!isCompleted}
+          />
+
+          {/* 상세 설명 작성 컴포넌트 */}
+          <DetailTextEditor isEditable={!isCompleted} />
+
+          {/* 댓글 영역 */}
+          {isCompleted && <CommentSection />}
+        </div>
+
+        {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
+        <div className="w-[33rem] h-full flex flex-col">
+          {/* 속성 탭 */}
+          <div className="w-full h-full flex flex-col gap-[1.6rem] ">
+            <div className="w-full font-title-sub-r tex-gray-600">속성</div>
+            <div>
+              {/* (1) 상태 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="상태"
+                  options={['없음', '해야할 일', '진행중', '완료', '검토']}
+                  getColor={(label) => {
+                    const code = statusLabelToCode[label] ?? 'NONE';
+                    return getStatusColor(code);
+                  }}
+                />
+              </div>
+
+              {/* (2) 우선순위 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="우선순위"
+                  options={['없음', '긴급', '높음', '중간', '낮음']}
+                  iconMap={priorityIconMap}
+                />
+              </div>
+
+              {/* (3) 담당자 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="담당자"
+                  options={['없음', '전채운', '전시현']}
+                  iconMap={userIconMap}
+                />
+              </div>
+
+              {/* (4) 기한 */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: 'date' });
+                }}
+                className="flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer"
+              >
+                {/* '기한' 속성 아이콘 */}
+                <img src={IcCalendar} alt="date" />
+                <div className="relative">
+                  {/* '기한' 항목명 - 날짜 설정하면 반영됨 */}
+                  <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
+                  {/* 달력 드롭다운 오픈 */}
+                  {isOpen && content?.name === 'date' && (
+                    <CalendarDropdown
+                      selectedDate={selectedDate}
+                      onSelect={(date) => setSelectedDate(date)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {/* (5) 목표 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="목표"
+                  options={[
+                    '없음',
+                    '백호를 사용해서 다른 사람들과 협업해보기',
+                    '기획 및 요구사항 분석',
+                  ]}
+                  iconMap={goalIconMap}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 작성 완료 버튼 */}
+          <CompletionButton
+            isTitleFilled={title.trim().length > 0}
+            isCompleted={isCompleted}
+            onToggle={handleToggle}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
 
-export default IssueDetail;
+export default GoalDetail;

--- a/src/pages/issue/IssueHome.tsx
+++ b/src/pages/issue/IssueHome.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../types/testDummy';
 import type { GroupedIssue, IssueFilter } from '../../types/issue';
 import { getSortedGrouped } from '../../utils/listGroupSortUtils';
+import { useNavigate } from 'react-router-dom';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자', '목표'] as const;
 
@@ -24,6 +25,11 @@ const IssueHome = () => {
   const { isOpen, content } = useDropdownInfo();
   const { openDropdown, closeDropdown } = useDropdownActions();
   const [filter, setFilter] = useState<ItemFilter>('상태');
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(':issueId');
+  };
 
   // filter 변경마다 다른 데이터 선택 -> 추후 새로운 데이터 불러오도록
   const dimmyIssueGroups = useMemo<IssueFilter[]>(() => {
@@ -126,8 +132,13 @@ const IssueHome = () => {
                       </div>
                       <div className="text-gray-500 ml-[0.8rem]">{items.length}</div>
                     </div>
-                    {/* TODO : 추가 버튼 라우터 연결 */}
-                    <img src={PlusIcon} className="inline-block w-[2.4rem] h-[2.4rem]" alt="" />
+                    {/* 추가 버튼 */}
+                    <img
+                      src={PlusIcon}
+                      className="inline-block w-[2.4rem] h-[2.4rem]"
+                      alt=""
+                      onClick={handleClick}
+                    />
                   </div>
                   {/* 각 유형 별 요소 */}
                   {items.map((issue) => (

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -12,6 +12,7 @@ import WorkspaceIssue from '../pages/workspace/WorkspaceIssue.tsx';
 import WorkspaceGoal from '../pages/workspace/WorkspaceGoal.tsx';
 import WorkspaceExternal from '../pages/workspace/WorkspaceExternal.tsx';
 import GoalDetail from '../pages/goal/GoalDetail.tsx';
+import IssueDetail from '../pages/issue/IssueDetail.tsx';
 
 export const protectedRoutes: RouteObject[] = [
   {
@@ -66,7 +67,7 @@ export const protectedRoutes: RouteObject[] = [
           { path: 'goal', element: <GoalHome /> },
           { path: 'goal/:goalId', element: <GoalDetail /> },
           { path: 'issue', element: <IssueHome /> },
-          { path: 'issue/:issueId', element: <div>Issue_Detail</div> },
+          { path: 'issue/:issueId', element: <IssueDetail /> },
           { path: 'ext', element: <ExternalHome /> },
           { path: 'ext/:extId', element: <div>External_Detail</div> },
         ],


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #85 

---

### ✅ Key Changes
detailView 컴포넌트를 활용해서 이슈 상세페이지를 구현했습니다.
(상세 내용은 목표 상세페이지와 동일함. #94 )

---

### 📸 스크린샷 or 실행영상

https://github.com/user-attachments/assets/1ee29269-523e-4050-bbad-6985d6ca33fc

---

### 💬 To Reviewers

- 상세페이지 헤더의 ID가 현재는 "Veco-g1"으로, 이슈가 아닌 목표 상세페이지의 ID 체계로 나와있는데, 해당 내용은 더미데이터에서 가져오는 데이터라 그렇습니다. 이후 실제 API 연동시에 수정하겠습니다.