### PR TITLE
[UI] 워크스페이스 전체 팀 상세페이지

### DIFF
--- a/src/components/DetailView/PropertyItem.tsx
+++ b/src/components/DetailView/PropertyItem.tsx
@@ -7,7 +7,7 @@
  *   (즉, 속성은 언제나 수정 가능함)
  *
  * @todo
- * - 현재는 '기한' 속성과 '이슈' 속성의 드롭다운은 이 컴포넌트에서 관리하지 않음.
+ * - 현재는 '기한' 속성과 '이슈', '목표' 속성의 드롭다운은 이 컴포넌트에서 관리하지 않음.
  * - 추후 더 나은 컴포넌트 연결 방식 고민해보고 리팩토링 예정.
  */
 
@@ -58,7 +58,7 @@ const PropertyItem = ({ defaultValue, options, iconMap, getColor }: PropertyItem
       <div className={`flex relative`}>
         <div className="flex items-center">
           {/* 속성 항목명 */}
-          <div className="font-body-r text-gray-600">{value}</div>
+          <div className="font-body-r text-gray-600 truncate">{value}</div>
         </div>
 
         {/* 드롭다운 오픈 */}

--- a/src/components/DetailView/WorkspaceDetailHeader.tsx
+++ b/src/components/DetailView/WorkspaceDetailHeader.tsx
@@ -1,0 +1,37 @@
+// WorkspaceDetailHeader.tsx
+// 워크스페이스 전체 팀 - 상세페이지 헤더 컴포넌트
+
+import { dummyStatusGoalGroups } from '../../types/testDummy';
+import WorkspaceIcon from '../ListView/WorkspaceIcon';
+
+interface WorkspaceDetailHeaderProps {
+  defaultTitle: string; // 상세페이지 제목에 아무것도 입력되지 않았을 때 기본 타이틀
+  title: string; // 상세페이지 제목으로부터 전달받아올 타이틀
+}
+
+const WorkspaceDetailHeader = ({ defaultTitle, title }: WorkspaceDetailHeaderProps) => {
+  // 상세페이지의 ID 체계 : 일단 dummy 데이터 첫번째를 임의로 가져옴.
+  // 추후 실제 API 연결하면서 다시 작성할 예정
+  const groupIndex = 0;
+  const goalIndex = 0;
+  const detailId = dummyStatusGoalGroups[groupIndex]?.goals[goalIndex]?.name;
+
+  return (
+    <div className="flex gap-[3.2rem] flex-nowrap">
+      {/* 워크스페이스 아이콘, 워크스페이스명, props로 요소 전달 가능 */}
+      <WorkspaceIcon />
+      <div className="flex gap-[1.6rem] items-center overflow-hidden">
+        {/* 상세페이지 ID */}
+        <div className="flex whitespace-nowrap font-body-b text-gray-600">{detailId}</div>
+        {/**
+         * 상세페이지 이름
+         * - 상세페이지 제목에 아무것도 입력되지 않았을 때는 defaultTitle(placeholder명과 동일) 렌더링
+         * - 입력됐을 때는 title(상세페이지 제목에 입력한 문자열) 렌더링
+         */}
+        <div className="font-body-r text-gray-400 truncate">{title || defaultTitle}</div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceDetailHeader;

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -1,0 +1,184 @@
+// ExternalDetail.tsx
+// 외부 상세페이지
+
+import { useState } from 'react';
+import DetailHeader from '../../components/DetailView/DetailHeader';
+import PropertyItem from '../../components/DetailView/PropertyItem';
+import DetailTitle from '../../components/DetailView/DetailTitle';
+import CompletionButton from '../../components/DetailView/CompletionButton';
+import DetailTextEditor from '../../components/DetailView/DetailTextEditor';
+
+// 속성 항목별 아이콘 svg import
+import pr1 from '../../assets/icons/pr-1-sm.svg';
+import pr2 from '../../assets/icons/pr-2-sm.svg';
+import pr3 from '../../assets/icons/pr-3-sm.svg';
+import pr4 from '../../assets/icons/pr-4-sm.svg';
+import IcProfile from '../../assets/icons/user-circle-sm.svg';
+import IcCalendar from '../../assets/icons/date-lg.svg';
+import IcGoal from '../../assets/icons/goal.svg';
+
+import { getStatusColor } from '../../utils/listItemUtils';
+import { statusLabelToCode } from '../../types/detailitem';
+import CommentSection from '../../components/DetailView/Comment/CommentSection';
+import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
+import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
+import { formatDateDot } from '../../utils/formatDate';
+
+const ExternalDetail = () => {
+  const [title, setTitle] = useState('');
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+
+  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
+  const { openDropdown } = useDropdownActions();
+
+  // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
+  const getDisplayText = () => {
+    const [start, end] = selectedDate;
+    if (start && end) return `${formatDateDot(start)} - ${formatDateDot(end)}`; // 시작일과 종료일 둘 다 있을 경우
+    if (start || end) return formatDateDot(start ?? end!); // 날짜 하나만 선택된 경우
+    return '기한'; // 날짜 선택 안 된 경우: default로 '기한' 글씨가 그대로 보이도록
+  };
+
+  // '우선순위' 속성 아이콘 매핑
+  const priorityIconMap = {
+    우선순위: pr3,
+    없음: pr3,
+    낮음: pr1,
+    중간: pr2,
+    높음: pr3,
+    긴급: pr4,
+  };
+
+  // '담당자' 속성 아이콘 매핑 (나중에 API로부터 받아온 데이터로 대체 예정)
+  const userIconMap = {
+    담당자: IcProfile,
+    없음: IcProfile,
+    전채운: IcProfile,
+    전시현: IcProfile,
+  };
+
+  const goalIconMap = {
+    목표: IcGoal,
+    없음: IcGoal,
+    '백호를 사용해서 다른 사람들과 협업해보기': IcGoal,
+    '기획 및 요구사항 분석': IcGoal,
+  };
+
+  const handleToggle = () => {
+    setIsCompleted((prev) => !prev);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
+      {/* 상세페이지 헤더 */}
+      <DetailHeader defaultTitle="이슈를 생성하세요" title={title} />
+
+      {/* 상세페이지 메인 */}
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
+        {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
+          {/* 상세페이지 제목 */}
+          <DetailTitle
+            defaultTitle="이슈를 생성하세요"
+            title={title}
+            setTitle={setTitle}
+            isEditable={!isCompleted}
+          />
+
+          {/* 상세 설명 작성 컴포넌트 */}
+          <DetailTextEditor isEditable={!isCompleted} />
+
+          {/* 댓글 영역 */}
+          {isCompleted && <CommentSection />}
+        </div>
+
+        {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
+        <div className="w-[33rem] h-full flex flex-col">
+          {/* 속성 탭 */}
+          <div className="w-full h-full flex flex-col gap-[1.6rem] ">
+            <div className="w-full font-title-sub-r tex-gray-600">속성</div>
+            <div>
+              {/* (1) 상태 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="상태"
+                  options={['없음', '해야할 일', '진행중', '완료', '검토']}
+                  getColor={(label) => {
+                    const code = statusLabelToCode[label] ?? 'NONE';
+                    return getStatusColor(code);
+                  }}
+                />
+              </div>
+
+              {/* (2) 우선순위 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="우선순위"
+                  options={['없음', '긴급', '높음', '중간', '낮음']}
+                  iconMap={priorityIconMap}
+                />
+              </div>
+
+              {/* (3) 담당자 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="담당자"
+                  options={['없음', '전채운', '전시현']}
+                  iconMap={userIconMap}
+                />
+              </div>
+
+              {/* (4) 기한 */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: 'date' });
+                }}
+                className="flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer"
+              >
+                {/* '기한' 속성 아이콘 */}
+                <img src={IcCalendar} alt="date" />
+                <div className="relative">
+                  {/* '기한' 항목명 - 날짜 설정하면 반영됨 */}
+                  <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
+                  {/* 달력 드롭다운 오픈 */}
+                  {isOpen && content?.name === 'date' && (
+                    <CalendarDropdown
+                      selectedDate={selectedDate}
+                      onSelect={(date) => setSelectedDate(date)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {/* (5) 목표 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="목표"
+                  options={[
+                    '없음',
+                    '백호를 사용해서 다른 사람들과 협업해보기',
+                    '기획 및 요구사항 분석',
+                  ]}
+                  iconMap={goalIconMap}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 작성 완료 버튼 */}
+          <CompletionButton
+            isTitleFilled={title.trim().length > 0}
+            isCompleted={isCompleted}
+            onToggle={handleToggle}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExternalDetail;

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -16,6 +16,7 @@ import pr4 from '../../assets/icons/pr-4-sm.svg';
 import IcProfile from '../../assets/icons/user-circle-sm.svg';
 import IcCalendar from '../../assets/icons/date-lg.svg';
 import IcGoal from '../../assets/icons/goal.svg';
+import IcExt from '../../assets/icons/external.svg';
 
 import { getStatusColor } from '../../utils/listItemUtils';
 import { statusLabelToCode } from '../../types/detailitem';
@@ -67,6 +68,13 @@ const ExternalDetail = () => {
     '기획 및 요구사항 분석': IcGoal,
   };
 
+  const externalIconMap = {
+    외부: IcExt,
+    Slack: IcExt,
+    Notion: IcExt,
+    Github: IcExt,
+  };
+
   const handleToggle = () => {
     setIsCompleted((prev) => !prev);
   };
@@ -74,7 +82,7 @@ const ExternalDetail = () => {
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
-      <DetailHeader defaultTitle="이슈를 생성하세요" title={title} />
+      <DetailHeader defaultTitle="제목을 작성해보세요" title={title} />
 
       {/* 상세페이지 메인 */}
       <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
@@ -82,7 +90,7 @@ const ExternalDetail = () => {
         <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
           {/* 상세페이지 제목 */}
           <DetailTitle
-            defaultTitle="이슈를 생성하세요"
+            defaultTitle="제목을 작성해보세요"
             title={title}
             setTitle={setTitle}
             isEditable={!isCompleted}
@@ -164,6 +172,15 @@ const ExternalDetail = () => {
                     '기획 및 요구사항 분석',
                   ]}
                   iconMap={goalIconMap}
+                />
+              </div>
+
+              {/* (6) 외부 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="외부"
+                  options={['Slack', 'Notion', 'Github']}
+                  iconMap={externalIconMap}
                 />
               </div>
             </div>

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -1,0 +1,5 @@
+const IssueDetail = () => {
+  return <div></div>;
+};
+
+export default IssueDetail;

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -24,7 +24,7 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 
-const GoalDetail = () => {
+const IssueDetail = () => {
   const [title, setTitle] = useState('');
   const [isCompleted, setIsCompleted] = useState(false);
 
@@ -181,4 +181,4 @@ const GoalDetail = () => {
   );
 };
 
-export default GoalDetail;
+export default IssueDetail;

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -1,5 +1,184 @@
-const IssueDetail = () => {
-  return <div></div>;
+// IssueDetail.tsx
+// 이슈 상세페이지
+
+import { useState } from 'react';
+import DetailHeader from '../../components/DetailView/DetailHeader';
+import PropertyItem from '../../components/DetailView/PropertyItem';
+import DetailTitle from '../../components/DetailView/DetailTitle';
+import CompletionButton from '../../components/DetailView/CompletionButton';
+import DetailTextEditor from '../../components/DetailView/DetailTextEditor';
+
+// 속성 항목별 아이콘 svg import
+import pr1 from '../../assets/icons/pr-1-sm.svg';
+import pr2 from '../../assets/icons/pr-2-sm.svg';
+import pr3 from '../../assets/icons/pr-3-sm.svg';
+import pr4 from '../../assets/icons/pr-4-sm.svg';
+import IcProfile from '../../assets/icons/user-circle-sm.svg';
+import IcCalendar from '../../assets/icons/date-lg.svg';
+import IcGoal from '../../assets/icons/goal.svg';
+
+import { getStatusColor } from '../../utils/listItemUtils';
+import { statusLabelToCode } from '../../types/detailitem';
+import CommentSection from '../../components/DetailView/Comment/CommentSection';
+import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
+import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
+import { formatDateDot } from '../../utils/formatDate';
+
+const GoalDetail = () => {
+  const [title, setTitle] = useState('');
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+
+  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
+  const { openDropdown } = useDropdownActions();
+
+  // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
+  const getDisplayText = () => {
+    const [start, end] = selectedDate;
+    if (start && end) return `${formatDateDot(start)} - ${formatDateDot(end)}`; // 시작일과 종료일 둘 다 있을 경우
+    if (start || end) return formatDateDot(start ?? end!); // 날짜 하나만 선택된 경우
+    return '기한'; // 날짜 선택 안 된 경우: default로 '기한' 글씨가 그대로 보이도록
+  };
+
+  // '우선순위' 속성 아이콘 매핑
+  const priorityIconMap = {
+    우선순위: pr3,
+    없음: pr3,
+    낮음: pr1,
+    중간: pr2,
+    높음: pr3,
+    긴급: pr4,
+  };
+
+  // '담당자' 속성 아이콘 매핑 (나중에 API로부터 받아온 데이터로 대체 예정)
+  const userIconMap = {
+    담당자: IcProfile,
+    없음: IcProfile,
+    전채운: IcProfile,
+    전시현: IcProfile,
+  };
+
+  const goalIconMap = {
+    목표: IcGoal,
+    없음: IcGoal,
+    '백호를 사용해서 다른 사람들과 협업해보기': IcGoal,
+    '기획 및 요구사항 분석': IcGoal,
+  };
+
+  const handleToggle = () => {
+    setIsCompleted((prev) => !prev);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
+      {/* 상세페이지 헤더 */}
+      <DetailHeader defaultTitle="이슈를 생성하세요" title={title} />
+
+      {/* 상세페이지 메인 */}
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
+        {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
+          {/* 상세페이지 제목 */}
+          <DetailTitle
+            defaultTitle="이슈를 생성하세요"
+            title={title}
+            setTitle={setTitle}
+            isEditable={!isCompleted}
+          />
+
+          {/* 상세 설명 작성 컴포넌트 */}
+          <DetailTextEditor isEditable={!isCompleted} />
+
+          {/* 댓글 영역 */}
+          {isCompleted && <CommentSection />}
+        </div>
+
+        {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
+        <div className="w-[33rem] h-full flex flex-col">
+          {/* 속성 탭 */}
+          <div className="w-full h-full flex flex-col gap-[1.6rem] ">
+            <div className="w-full font-title-sub-r tex-gray-600">속성</div>
+            <div>
+              {/* (1) 상태 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="상태"
+                  options={['없음', '해야할 일', '진행중', '완료', '검토']}
+                  getColor={(label) => {
+                    const code = statusLabelToCode[label] ?? 'NONE';
+                    return getStatusColor(code);
+                  }}
+                />
+              </div>
+
+              {/* (2) 우선순위 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="우선순위"
+                  options={['없음', '긴급', '높음', '중간', '낮음']}
+                  iconMap={priorityIconMap}
+                />
+              </div>
+
+              {/* (3) 담당자 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="담당자"
+                  options={['없음', '전채운', '전시현']}
+                  iconMap={userIconMap}
+                />
+              </div>
+
+              {/* (4) 기한 */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: 'date' });
+                }}
+                className="flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer"
+              >
+                {/* '기한' 속성 아이콘 */}
+                <img src={IcCalendar} alt="date" />
+                <div className="relative">
+                  {/* '기한' 항목명 - 날짜 설정하면 반영됨 */}
+                  <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
+                  {/* 달력 드롭다운 오픈 */}
+                  {isOpen && content?.name === 'date' && (
+                    <CalendarDropdown
+                      selectedDate={selectedDate}
+                      onSelect={(date) => setSelectedDate(date)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {/* (5) 목표 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="목표"
+                  options={[
+                    '없음',
+                    '백호를 사용해서 다른 사람들과 협업해보기',
+                    '기획 및 요구사항 분석',
+                  ]}
+                  iconMap={goalIconMap}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 작성 완료 버튼 */}
+          <CompletionButton
+            isTitleFilled={title.trim().length > 0}
+            isCompleted={isCompleted}
+            onToggle={handleToggle}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
 
-export default IssueDetail;
+export default GoalDetail;

--- a/src/pages/workspace/WorkspaceExternal.tsx
+++ b/src/pages/workspace/WorkspaceExternal.tsx
@@ -24,6 +24,7 @@ import GroupTypeIcon from '../../components/ListView/GroupTypeIcon';
 import { ExternalItem } from '../../components/ListView/ExternalItem';
 import WorkspaceIcon from '../../components/ListView/WorkspaceIcon';
 import ExternalToolArea from '../external/components/ExternalToolArea';
+import { useNavigate } from 'react-router-dom';
 
 const FILTER_OPTIONS = ['상태', '우선순위', '담당자', '목표', '외부'] as const;
 
@@ -31,6 +32,11 @@ const WorkspaceExternal = () => {
   const { isOpen, content } = useDropdownInfo();
   const { openDropdown, closeDropdown } = useDropdownActions();
   const [filter, setFilter] = useState<ItemFilter>('상태');
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(':extId');
+  };
 
   // filter 변경마다 다른 데이터 선택 -> 추후 새로운 데이터 불러오도록
   const dummyExternalGroups = useMemo<ExternalFilter[]>(() => {
@@ -140,8 +146,13 @@ const WorkspaceExternal = () => {
                       </div>
                       <div className="text-gray-500 ml-[0.8rem]">{items.length}</div>
                     </div>
-                    {/* TODO : 추가 버튼 라우터 연결 */}
-                    <img src={PlusIcon} className="inline-block w-[2.4rem] h-[2.4rem]" alt="" />
+                    {/* 추가 버튼 */}
+                    <img
+                      src={PlusIcon}
+                      className="inline-block w-[2.4rem] h-[2.4rem]"
+                      alt=""
+                      onClick={handleClick}
+                    />
                   </div>
                   {/* 각 유형 별 요소 */}
                   {items.map((externals) => (

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -1,5 +1,5 @@
-// WorkspaceGoalDetail.tsx
-// 워크스페이스 전체 팀 목표 상세페이지
+// WorkspaceExternalDetail.tsx
+// 워크스페이스 전체 팀 외부 상세페이지
 
 import { useState } from 'react';
 import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
@@ -15,7 +15,8 @@ import pr3 from '../../assets/icons/pr-3-sm.svg';
 import pr4 from '../../assets/icons/pr-4-sm.svg';
 import IcProfile from '../../assets/icons/user-circle-sm.svg';
 import IcCalendar from '../../assets/icons/date-lg.svg';
-import IcIssue from '../../assets/icons/issue.svg';
+import IcGoal from '../../assets/icons/goal.svg';
+import IcExt from '../../assets/icons/external.svg';
 
 import { getStatusColor } from '../../utils/listItemUtils';
 import { statusLabelToCode } from '../../types/detailitem';
@@ -23,18 +24,16 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 
-const WorkspaceGoalDetail = () => {
+const WorkspaceExternalDetail = () => {
   const [title, setTitle] = useState('');
   const [isCompleted, setIsCompleted] = useState(false);
 
   // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
 
-  const [option, setOption] = useState<string>('이슈');
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
-  const { openDropdown, closeDropdown } = useDropdownActions();
+  const { openDropdown } = useDropdownActions();
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -62,8 +61,19 @@ const WorkspaceGoalDetail = () => {
     전시현: IcProfile,
   };
 
-  // const dateIconMap = IcDate; // '기한' 속성 아이콘 매핑
-  // const issueIconMap = IcIssue; // '이슈' 속성 아이콘 매핑
+  const goalIconMap = {
+    목표: IcGoal,
+    없음: IcGoal,
+    '백호를 사용해서 다른 사람들과 협업해보기': IcGoal,
+    '기획 및 요구사항 분석': IcGoal,
+  };
+
+  const externalIconMap = {
+    외부: IcExt,
+    Slack: IcExt,
+    Notion: IcExt,
+    Github: IcExt,
+  };
 
   const handleToggle = () => {
     setIsCompleted((prev) => !prev);
@@ -72,7 +82,7 @@ const WorkspaceGoalDetail = () => {
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
-      <WorkspaceDetailHeader defaultTitle="목표를 생성하세요" title={title} />
+      <WorkspaceDetailHeader defaultTitle="제목을 작성해보세요" title={title} />
 
       {/* 상세페이지 메인 */}
       <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
@@ -80,7 +90,7 @@ const WorkspaceGoalDetail = () => {
         <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
           {/* 상세페이지 제목 */}
           <DetailTitle
-            defaultTitle="목표를 생성하세요"
+            defaultTitle="제목을 작성해보세요"
             title={title}
             setTitle={setTitle}
             isEditable={!isCompleted}
@@ -152,38 +162,26 @@ const WorkspaceGoalDetail = () => {
                 </div>
               </div>
 
-              {/* (5) 이슈 */}
-              <div
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openDropdown({ name: '이슈' });
-                }}
-                className={`flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer`}
-              >
-                {/* 속성 아이콘 */}
-                <img src={IcIssue} alt="이슈" />
+              {/* (5) 목표 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="목표"
+                  options={[
+                    '없음',
+                    '백호를 사용해서 다른 사람들과 협업해보기',
+                    '기획 및 요구사항 분석',
+                  ]}
+                  iconMap={goalIconMap}
+                />
+              </div>
 
-                {/* 속성 이름 */}
-                <div className="flex relative">
-                  <div className="flex items-center">
-                    {/* 속성 항목명 */}
-                    <div className="font-body-r text-gray-600">{option}</div>
-                  </div>
-
-                  {/* 드롭다운 오픈 */}
-                  {isOpen && content?.name === '이슈' && (
-                    <ArrowDropdown
-                      defaultValue={'이슈'}
-                      options={[
-                        '기능 정의: 구현할 핵심 기능과 어쩌구 저쩌구 텍스트가 길어지면 이렇게 표시',
-                        '와이어프레임 디자인',
-                        '컴포넌트 정리',
-                      ]}
-                      onSelect={(value: string) => setOption(value)}
-                      onClose={closeDropdown}
-                    />
-                  )}
-                </div>
+              {/* (6) 외부 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="외부"
+                  options={['Slack', 'Notion', 'Github']}
+                  iconMap={externalIconMap}
+                />
               </div>
             </div>
           </div>
@@ -200,4 +198,4 @@ const WorkspaceGoalDetail = () => {
   );
 };
 
-export default WorkspaceGoalDetail;
+export default WorkspaceExternalDetail;

--- a/src/pages/workspace/WorkspaceGoal.tsx
+++ b/src/pages/workspace/WorkspaceGoal.tsx
@@ -16,6 +16,7 @@ import {
 import type { GoalFilter, GroupedGoal } from '../../types/goal';
 import { getSortedGrouped } from '../../utils/listGroupSortUtils';
 import WorkspaceIcon from '../../components/ListView/WorkspaceIcon';
+import { useNavigate } from 'react-router-dom';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자'] as const;
 
@@ -23,6 +24,11 @@ const WorkspaceGoal = () => {
   const { isOpen, content } = useDropdownInfo();
   const { openDropdown, closeDropdown } = useDropdownActions();
   const [filter, setFilter] = useState<ItemFilter>('상태');
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(':goalId');
+  };
 
   // filter 변경마다 다른 데이터 선택 -> 추후 새로운 데이터 불러오도록
   const dummyGoalGroups = useMemo<GoalFilter[]>(() => {
@@ -122,8 +128,13 @@ const WorkspaceGoal = () => {
                       </div>
                       <div className="text-gray-500 ml-[0.8rem]">{items.length}</div>
                     </div>
-                    {/* TODO : 추가 버튼 라우터 연결 */}
-                    <img src={PlusIcon} className="inline-block w-[2.4rem] h-[2.4rem]" alt="" />
+                    {/* 추가 버튼 */}
+                    <img
+                      src={PlusIcon}
+                      className="inline-block w-[2.4rem] h-[2.4rem]"
+                      alt=""
+                      onClick={handleClick}
+                    />
                   </div>
                   {/* 각 유형 별 요소 */}
                   {items.map((goal) => (

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -165,10 +165,8 @@ const WorkspaceGoalDetail = () => {
 
                 {/* 속성 이름 */}
                 <div className="flex relative">
-                  <div className="flex items-center">
-                    {/* 속성 항목명 */}
-                    <div className="font-body-r text-gray-600">{option}</div>
-                  </div>
+                  {/* 속성 항목명 */}
+                  <p className="font-body-r text-gray-600 max-w-[27.4rem] truncate">{option}</p>
 
                   {/* 드롭다운 오픈 */}
                   {isOpen && content?.name === '이슈' && (

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -1,0 +1,203 @@
+// WorkspaceGoalDetail.tsx
+// 워크스페이스 전체 팀 목표 상세페이지
+
+import { useState } from 'react';
+import PropertyItem from '../../components/DetailView/PropertyItem';
+import DetailTitle from '../../components/DetailView/DetailTitle';
+import CompletionButton from '../../components/DetailView/CompletionButton';
+import DetailTextEditor from '../../components/DetailView/DetailTextEditor';
+
+// 속성 항목별 아이콘 svg import
+import pr1 from '../../assets/icons/pr-1-sm.svg';
+import pr2 from '../../assets/icons/pr-2-sm.svg';
+import pr3 from '../../assets/icons/pr-3-sm.svg';
+import pr4 from '../../assets/icons/pr-4-sm.svg';
+import IcProfile from '../../assets/icons/user-circle-sm.svg';
+import IcCalendar from '../../assets/icons/date-lg.svg';
+import IcIssue from '../../assets/icons/issue.svg';
+
+import { getStatusColor } from '../../utils/listItemUtils';
+import { statusLabelToCode } from '../../types/detailitem';
+import CommentSection from '../../components/DetailView/Comment/CommentSection';
+import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
+import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
+import { formatDateDot } from '../../utils/formatDate';
+import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
+import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
+
+const WorkspaceGoalDetail = () => {
+  const [title, setTitle] = useState('');
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+
+  const [option, setOption] = useState<string>('이슈');
+  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
+  const { openDropdown, closeDropdown } = useDropdownActions();
+
+  // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
+  const getDisplayText = () => {
+    const [start, end] = selectedDate;
+    if (start && end) return `${formatDateDot(start)} - ${formatDateDot(end)}`; // 시작일과 종료일 둘 다 있을 경우
+    if (start || end) return formatDateDot(start ?? end!); // 날짜 하나만 선택된 경우
+    return '기한'; // 날짜 선택 안 된 경우: default로 '기한' 글씨가 그대로 보이도록
+  };
+
+  // '우선순위' 속성 아이콘 매핑
+  const priorityIconMap = {
+    우선순위: pr3,
+    없음: pr3,
+    낮음: pr1,
+    중간: pr2,
+    높음: pr3,
+    긴급: pr4,
+  };
+
+  // '담당자' 속성 아이콘 매핑 (나중에 API로부터 받아온 데이터로 대체 예정)
+  const userIconMap = {
+    담당자: IcProfile,
+    없음: IcProfile,
+    전채운: IcProfile,
+    전시현: IcProfile,
+  };
+
+  // const dateIconMap = IcDate; // '기한' 속성 아이콘 매핑
+  // const issueIconMap = IcIssue; // '이슈' 속성 아이콘 매핑
+
+  const handleToggle = () => {
+    setIsCompleted((prev) => !prev);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
+      {/* 상세페이지 헤더 */}
+      <WorkspaceDetailHeader defaultTitle="목표를 생성하세요" title={title} />
+
+      {/* 상세페이지 메인 */}
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
+        {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
+          {/* 상세페이지 제목 */}
+          <DetailTitle
+            defaultTitle="목표를 생성하세요"
+            title={title}
+            setTitle={setTitle}
+            isEditable={!isCompleted}
+          />
+
+          {/* 상세 설명 작성 컴포넌트 */}
+          <DetailTextEditor isEditable={!isCompleted} />
+
+          {/* 댓글 영역 */}
+          {isCompleted && <CommentSection />}
+        </div>
+
+        {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
+        <div className="w-[33rem] h-full flex flex-col">
+          {/* 속성 탭 */}
+          <div className="w-full h-full flex flex-col gap-[1.6rem] ">
+            <div className="w-full font-title-sub-r tex-gray-600">속성</div>
+            <div>
+              {/* (1) 상태 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="상태"
+                  options={['없음', '해야할 일', '진행중', '완료', '검토']}
+                  getColor={(label) => {
+                    const code = statusLabelToCode[label] ?? 'NONE';
+                    return getStatusColor(code);
+                  }}
+                />
+              </div>
+
+              {/* (2) 우선순위 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="우선순위"
+                  options={['없음', '긴급', '높음', '중간', '낮음']}
+                  iconMap={priorityIconMap}
+                />
+              </div>
+
+              {/* (3) 담당자 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="담당자"
+                  options={['없음', '전채운', '전시현']}
+                  iconMap={userIconMap}
+                />
+              </div>
+
+              {/* (4) 기한 */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: 'date' });
+                }}
+                className="flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer"
+              >
+                {/* '기한' 속성 아이콘 */}
+                <img src={IcCalendar} alt="date" />
+                <div className="relative">
+                  {/* '기한' 항목명 - 날짜 설정하면 반영됨 */}
+                  <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
+                  {/* 달력 드롭다운 오픈 */}
+                  {isOpen && content?.name === 'date' && (
+                    <CalendarDropdown
+                      selectedDate={selectedDate}
+                      onSelect={(date) => setSelectedDate(date)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {/* (5) 이슈 */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: '이슈' });
+                }}
+                className={`flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer`}
+              >
+                {/* 속성 아이콘 */}
+                <img src={IcIssue} alt="이슈" />
+
+                {/* 속성 이름 */}
+                <div className="flex relative">
+                  <div className="flex items-center">
+                    {/* 속성 항목명 */}
+                    <div className="font-body-r text-gray-600">{option}</div>
+                  </div>
+
+                  {/* 드롭다운 오픈 */}
+                  {isOpen && content?.name === '이슈' && (
+                    <ArrowDropdown
+                      defaultValue={'이슈'}
+                      options={[
+                        '기능 정의: 구현할 핵심 기능과 어쩌구 저쩌구 텍스트가 길어지면 이렇게 표시',
+                        '와이어프레임 디자인',
+                        '컴포넌트 정리',
+                      ]}
+                      onSelect={(value: string) => setOption(value)}
+                      onClose={closeDropdown}
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 작성 완료 버튼 */}
+          <CompletionButton
+            isTitleFilled={title.trim().length > 0}
+            isCompleted={isCompleted}
+            onToggle={handleToggle}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceGoalDetail;

--- a/src/pages/workspace/WorkspaceIssue.tsx
+++ b/src/pages/workspace/WorkspaceIssue.tsx
@@ -17,6 +17,7 @@ import {
 import type { GroupedIssue, IssueFilter } from '../../types/issue';
 import { getSortedGrouped } from '../../utils/listGroupSortUtils';
 import WorkspaceIcon from '../../components/ListView/WorkspaceIcon';
+import { useNavigate } from 'react-router-dom';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자', '목표'] as const;
 
@@ -24,6 +25,11 @@ const WorkspaceIssue = () => {
   const { isOpen, content } = useDropdownInfo();
   const { openDropdown, closeDropdown } = useDropdownActions();
   const [filter, setFilter] = useState<ItemFilter>('상태');
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(':issueId');
+  };
 
   // filter 변경마다 다른 데이터 선택 -> 추후 새로운 데이터 불러오도록
   const dimmyIssueGroups = useMemo<IssueFilter[]>(() => {
@@ -126,8 +132,13 @@ const WorkspaceIssue = () => {
                       </div>
                       <div className="text-gray-500 ml-[0.8rem]">{items.length}</div>
                     </div>
-                    {/* TODO : 추가 버튼 라우터 연결 */}
-                    <img src={PlusIcon} className="inline-block w-[2.4rem] h-[2.4rem]" alt="" />
+                    {/* 추가 버튼 */}
+                    <img
+                      src={PlusIcon}
+                      className="inline-block w-[2.4rem] h-[2.4rem]"
+                      alt=""
+                      onClick={handleClick}
+                    />
                   </div>
                   {/* 각 유형 별 요소 */}
                   {items.map((issue) => (

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -2,6 +2,7 @@
 // 워크스페이스 전체 팀 - 이슈 상세페이지
 
 import { useState } from 'react';
+import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
 import PropertyItem from '../../components/DetailView/PropertyItem';
 import DetailTitle from '../../components/DetailView/DetailTitle';
 import CompletionButton from '../../components/DetailView/CompletionButton';
@@ -22,7 +23,6 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
 
 const WorkspaceIssueDetail = () => {
   const [title, setTitle] = useState('');

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -1,0 +1,184 @@
+// WorkspaceIssueDetail.tsx
+// 워크스페이스 전체 팀 - 이슈 상세페이지
+
+import { useState } from 'react';
+import PropertyItem from '../../components/DetailView/PropertyItem';
+import DetailTitle from '../../components/DetailView/DetailTitle';
+import CompletionButton from '../../components/DetailView/CompletionButton';
+import DetailTextEditor from '../../components/DetailView/DetailTextEditor';
+
+// 속성 항목별 아이콘 svg import
+import pr1 from '../../assets/icons/pr-1-sm.svg';
+import pr2 from '../../assets/icons/pr-2-sm.svg';
+import pr3 from '../../assets/icons/pr-3-sm.svg';
+import pr4 from '../../assets/icons/pr-4-sm.svg';
+import IcProfile from '../../assets/icons/user-circle-sm.svg';
+import IcCalendar from '../../assets/icons/date-lg.svg';
+import IcGoal from '../../assets/icons/goal.svg';
+
+import { getStatusColor } from '../../utils/listItemUtils';
+import { statusLabelToCode } from '../../types/detailitem';
+import CommentSection from '../../components/DetailView/Comment/CommentSection';
+import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
+import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
+import { formatDateDot } from '../../utils/formatDate';
+import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
+
+const WorkspaceIssueDetail = () => {
+  const [title, setTitle] = useState('');
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+
+  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
+  const { openDropdown } = useDropdownActions();
+
+  // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
+  const getDisplayText = () => {
+    const [start, end] = selectedDate;
+    if (start && end) return `${formatDateDot(start)} - ${formatDateDot(end)}`; // 시작일과 종료일 둘 다 있을 경우
+    if (start || end) return formatDateDot(start ?? end!); // 날짜 하나만 선택된 경우
+    return '기한'; // 날짜 선택 안 된 경우: default로 '기한' 글씨가 그대로 보이도록
+  };
+
+  // '우선순위' 속성 아이콘 매핑
+  const priorityIconMap = {
+    우선순위: pr3,
+    없음: pr3,
+    낮음: pr1,
+    중간: pr2,
+    높음: pr3,
+    긴급: pr4,
+  };
+
+  // '담당자' 속성 아이콘 매핑 (나중에 API로부터 받아온 데이터로 대체 예정)
+  const userIconMap = {
+    담당자: IcProfile,
+    없음: IcProfile,
+    전채운: IcProfile,
+    전시현: IcProfile,
+  };
+
+  const goalIconMap = {
+    목표: IcGoal,
+    없음: IcGoal,
+    '백호를 사용해서 다른 사람들과 협업해보기': IcGoal,
+    '기획 및 요구사항 분석': IcGoal,
+  };
+
+  const handleToggle = () => {
+    setIsCompleted((prev) => !prev);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
+      {/* 상세페이지 헤더 */}
+      <WorkspaceDetailHeader defaultTitle="이슈를 생성하세요" title={title} />
+
+      {/* 상세페이지 메인 */}
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">
+        {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] h-full">
+          {/* 상세페이지 제목 */}
+          <DetailTitle
+            defaultTitle="이슈를 생성하세요"
+            title={title}
+            setTitle={setTitle}
+            isEditable={!isCompleted}
+          />
+
+          {/* 상세 설명 작성 컴포넌트 */}
+          <DetailTextEditor isEditable={!isCompleted} />
+
+          {/* 댓글 영역 */}
+          {isCompleted && <CommentSection />}
+        </div>
+
+        {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
+        <div className="w-[33rem] h-full flex flex-col">
+          {/* 속성 탭 */}
+          <div className="w-full h-full flex flex-col gap-[1.6rem] ">
+            <div className="w-full font-title-sub-r tex-gray-600">속성</div>
+            <div>
+              {/* (1) 상태 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="상태"
+                  options={['없음', '해야할 일', '진행중', '완료', '검토']}
+                  getColor={(label) => {
+                    const code = statusLabelToCode[label] ?? 'NONE';
+                    return getStatusColor(code);
+                  }}
+                />
+              </div>
+
+              {/* (2) 우선순위 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="우선순위"
+                  options={['없음', '긴급', '높음', '중간', '낮음']}
+                  iconMap={priorityIconMap}
+                />
+              </div>
+
+              {/* (3) 담당자 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="담당자"
+                  options={['없음', '전채운', '전시현']}
+                  iconMap={userIconMap}
+                />
+              </div>
+
+              {/* (4) 기한 */}
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDropdown({ name: 'date' });
+                }}
+                className="flex w-full h-[3.2rem] px-[0.5rem] rounded-md items-center gap-[0.8rem] mb-[1.6rem] whitespace-nowrap hover:bg-gray-200 cursor-pointer"
+              >
+                {/* '기한' 속성 아이콘 */}
+                <img src={IcCalendar} alt="date" />
+                <div className="relative">
+                  {/* '기한' 항목명 - 날짜 설정하면 반영됨 */}
+                  <span className={`font-body-r text-gray-600`}>{getDisplayText()}</span>
+                  {/* 달력 드롭다운 오픈 */}
+                  {isOpen && content?.name === 'date' && (
+                    <CalendarDropdown
+                      selectedDate={selectedDate}
+                      onSelect={(date) => setSelectedDate(date)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {/* (5) 목표 */}
+              <div onClick={(e) => e.stopPropagation()}>
+                <PropertyItem
+                  defaultValue="목표"
+                  options={[
+                    '없음',
+                    '백호를 사용해서 다른 사람들과 협업해보기',
+                    '기획 및 요구사항 분석',
+                  ]}
+                  iconMap={goalIconMap}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 작성 완료 버튼 */}
+          <CompletionButton
+            isTitleFilled={title.trim().length > 0}
+            isCompleted={isCompleted}
+            onToggle={handleToggle}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceIssueDetail;

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -17,6 +17,7 @@ import SettingWorkspaceProfile from '../pages/setting/SettingWorkspaceProfile.ts
 import ExternalDetail from '../pages/external/ExternalDetail.tsx';
 import WorkspaceGoalDetail from '../pages/workspace/WorkspaceGoalDetail.tsx';
 import WorkspaceIssueDetail from '../pages/workspace/WorkspaceIssueDetail.tsx';
+import WorkspaceExternalDetail from '../pages/workspace/WorkspaceExternalDetail.tsx';
 
 export const protectedRoutes: RouteObject[] = [
   {
@@ -58,7 +59,7 @@ export const protectedRoutes: RouteObject[] = [
           { path: 'goal', element: <WorkspaceGoal /> },
           { path: 'goal/:goalId', element: <WorkspaceGoalDetail /> },
           { path: 'ext', element: <WorkspaceExternal /> },
-          { path: 'ext/:extId', element: <div>Workspace_External_Detail</div> },
+          { path: 'ext/:extId', element: <WorkspaceExternalDetail /> },
         ],
       },
       /* 팀별 페이지들 */

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -14,6 +14,7 @@ import WorkspaceExternal from '../pages/workspace/WorkspaceExternal.tsx';
 import GoalDetail from '../pages/goal/GoalDetail.tsx';
 import IssueDetail from '../pages/issue/IssueDetail.tsx';
 import SettingWorkspaceProfile from '../pages/setting/SettingWorkspaceProfile.tsx';
+import ExternalDetail from '../pages/external/ExternalDetail.tsx';
 
 export const protectedRoutes: RouteObject[] = [
   {
@@ -70,7 +71,7 @@ export const protectedRoutes: RouteObject[] = [
           { path: 'issue', element: <IssueHome /> },
           { path: 'issue/:issueId', element: <IssueDetail /> },
           { path: 'ext', element: <ExternalHome /> },
-          { path: 'ext/:extId', element: <div>External_Detail</div> },
+          { path: 'ext/:extId', element: <ExternalDetail /> },
         ],
       },
     ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -15,6 +15,8 @@ import GoalDetail from '../pages/goal/GoalDetail.tsx';
 import IssueDetail from '../pages/issue/IssueDetail.tsx';
 import SettingWorkspaceProfile from '../pages/setting/SettingWorkspaceProfile.tsx';
 import ExternalDetail from '../pages/external/ExternalDetail.tsx';
+import WorkspaceGoalDetail from '../pages/workspace/WorkspaceGoalDetail.tsx';
+import WorkspaceIssueDetail from '../pages/workspace/WorkspaceIssueDetail.tsx';
 
 export const protectedRoutes: RouteObject[] = [
   {
@@ -52,9 +54,9 @@ export const protectedRoutes: RouteObject[] = [
           // 기본 경로는 이슈 페이지로 리다이렉트
           { index: true, element: <Navigate to="issue" replace /> },
           { path: 'issue', element: <WorkspaceIssue /> },
-          { path: 'issue/:issueId', element: <div>Workspace_Issue_Detail</div> },
+          { path: 'issue/:issueId', element: <WorkspaceIssueDetail /> },
           { path: 'goal', element: <WorkspaceGoal /> },
-          { path: 'goal/:goalId', element: <div>Workspace_Goal_Detail</div> },
+          { path: 'goal/:goalId', element: <WorkspaceGoalDetail /> },
           { path: 'ext', element: <WorkspaceExternal /> },
           { path: 'ext/:extId', element: <div>Workspace_External_Detail</div> },
         ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -12,6 +12,7 @@ import WorkspaceIssue from '../pages/workspace/WorkspaceIssue.tsx';
 import WorkspaceGoal from '../pages/workspace/WorkspaceGoal.tsx';
 import WorkspaceExternal from '../pages/workspace/WorkspaceExternal.tsx';
 import GoalDetail from '../pages/goal/GoalDetail.tsx';
+import IssueDetail from '../pages/issue/IssueDetail.tsx';
 
 export const protectedRoutes: RouteObject[] = [
   {
@@ -66,7 +67,7 @@ export const protectedRoutes: RouteObject[] = [
           { path: 'goal', element: <GoalHome /> },
           { path: 'goal/:goalId', element: <GoalDetail /> },
           { path: 'issue', element: <IssueHome /> },
-          { path: 'issue/:issueId', element: <div>Issue_Detail</div> },
+          { path: 'issue/:issueId', element: <IssueDetail /> },
           { path: 'ext', element: <ExternalHome /> },
           { path: 'ext/:extId', element: <div>External_Detail</div> },
         ],


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #108 

---

### ✅ Key Changes
기존의 각 팀별 상세페이지를 기반으로, 워크스페이스 전체 팀의 목표/이슈/외부 상세페이지를 구현했습니다.

주요 업데이트:
- `WorkspaceDetailHeader` 컴포넌트 생성: 기존 상세페이지 상단의 헤더(`DetailHeader`)에서 `TeamIcon` 대신 `WorkspaceIcon`을 적용하여 변경.
- `WorkspaceGoalDetail.tsx` 워크스페이스 전체 팀 목표 상세페이지 구현
- `WorkspaceIssueDetail.tsx` 워크스페이스 전체 팀 이슈 상세페이지 구현
- `WorkspaceExternalDetail.tsx` 워크스페이스 전체 팀 외부 상세페이지 구현
- `ProtectedRoutes.tsx`의 기존 placeholder에 해당 페이지 파일들 연결해두었습니다.

주요 파일 경로: `src/pages/workspace` 폴더 내

---

### 📸 스크린샷 or 실행영상

1. 워크스페이스 전체 팀 - 목표
<img width="1552" height="1152" alt="스크린샷 2025-08-01 오후 2 11 29" src="https://github.com/user-attachments/assets/a768aaea-b19a-4be2-a80e-418c5f1308b2" />
<br><br>
2. 워크스페이스 전체 팀 - 이슈
<img width="1552" height="1152" alt="스크린샷 2025-08-01 오후 2 11 36" src="https://github.com/user-attachments/assets/8e5410d9-c492-43c5-9b24-8371ccfdd823" />
<br><br>
3. 워크스페이스 전체 팀 - 외부
<img width="1552" height="1152" alt="스크린샷 2025-08-01 오후 2 11 22" src="https://github.com/user-attachments/assets/2c3002dd-d7e5-4056-a525-a41340c2091f" />


---

### 💬 To Reviewers

(워크스페이스 전체팀 페이지들은 잊고 있었는데 뒤늦게 후다닥 올립니다.. ㅜㅜ)
