### PR TITLE
[REFACTOR] 세팅페이지 API 응답 변수명 통일

### DIFF
--- a/src/apis/setting/useGetMyProfile.ts
+++ b/src/apis/setting/useGetMyProfile.ts
@@ -1,10 +1,10 @@
 import { axiosInstance } from '../axios';
-import type { MyProfile } from '../../types/setting';
+import type { MyProfileResponse } from '../../types/setting';
 import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey';
 
 // 설정 - 나의 프로필 조회
-const getMyProfile = async (): Promise<MyProfile> => {
+const getMyProfile = async (): Promise<MyProfileResponse> => {
   try {
     const response = await axiosInstance.get('/api/workspace/setting/my-profile');
     return response.data.result;

--- a/src/apis/setting/useGetWorkspaceProfile.ts
+++ b/src/apis/setting/useGetWorkspaceProfile.ts
@@ -1,10 +1,10 @@
-import type { Workspace } from '../../types/setting';
+import type { WorkspaceResponse } from '../../types/setting';
 import { axiosInstance } from '../axios';
 import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey';
 
 // 설정 - 워크스페이스 프로필 조회
-const getWorkspaceProfile = async (): Promise<Workspace> => {
+const getWorkspaceProfile = async (): Promise<WorkspaceResponse> => {
   try {
     const response = await axiosInstance.get('/api/workspace/setting/profile');
     return response.data.result;

--- a/src/apis/setting/usePatchMyProfileImage.ts
+++ b/src/apis/setting/usePatchMyProfileImage.ts
@@ -1,11 +1,11 @@
 import { axiosInstance } from '../axios';
-import type { MyProfileImage } from '../../types/setting';
+import type { MyProfileImageResponse } from '../../types/setting';
 import { useMutation } from '@tanstack/react-query';
 import queryClient from '../../utils/queryClient';
 import { queryKey } from '../../constants/queryKey';
 
 // 설정 - 나의 프로필 이미지 변경
-const patchMyProfileImage = async (formData: FormData): Promise<MyProfileImage> => {
+const patchMyProfileImage = async (formData: FormData): Promise<MyProfileImageResponse> => {
   try {
     const response = await axiosInstance.patch(
       '/api/workspace/setting/my-profile/profileImage',

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -16,7 +16,7 @@ import hamburgerIcon from '../../assets/icons/hamburger.svg';
 import SortableDropdownList from './SortableDropdownList';
 import vecocirclewhite from '../../assets/logos/veco-circle-logo-bg-white.svg';
 // import { usePatchWorkspaceTeams } from '../../apis/setting/usePatchWorkspaceTeams';
-import type { Team } from './types';
+import type { Team } from '../../types/setting';
 
 interface FullSidebarContentProps {
   setExpanded: (value: boolean) => void;
@@ -148,9 +148,11 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
               items={teams}
               renderContent={(team, { listeners, attributes }, isOverlay) => (
                 <DropdownMenu
-                  headerTitle={team.name}
+                  headerTitle={team.teamName}
                   initialOpen={!isOverlay}
-                  headerTeamIcon={<img src={team.profileUrl || vecocirclewhite} alt={team.name} />}
+                  headerTeamIcon={
+                    <img src={team.teamImageUrl || vecocirclewhite} alt={team.teamName} />
+                  }
                   isNested={true}
                   dragHandle={
                     <button {...attributes} {...listeners} type="button" className="cursor-grab">

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -12,7 +12,7 @@ import externalHoverIcon from '../../assets/icons/external-hover.svg';
 import DropdownMenu from './DropdownMenu';
 import SidebarItem from './SidebarItem';
 import SortableDropdownList from './SortableDropdownList';
-import type { Team } from './types';
+import type { Team } from '../../types/setting';
 
 interface MiniSidebarContentProps {
   setExpanded: (value: boolean) => void;
@@ -116,7 +116,7 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                 <DropdownMenu
                   headerTitle=""
                   initialOpen={!isOverlay}
-                  headerTeamIcon={team.profileUrl}
+                  headerTeamIcon={team.teamImageUrl}
                   isNested={true}
                 >
                   {!isOverlay && (

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -13,15 +13,15 @@ const Sidebar = () => {
   const teams = [
     {
       teamId: 2,
-      name: 'Team1',
-      profileUrl: vecocirclewhite,
+      teamName: 'Team1',
+      teamImageUrl: vecocirclewhite,
       memberCount: 2,
       createdAt: '2025-01-01',
     },
     {
       teamId: 3,
-      name: 'Team2',
-      profileUrl: vecocirclewhite,
+      teamName: 'Team2',
+      teamImageUrl: vecocirclewhite,
       memberCount: 2,
       createdAt: '2025-01-01',
     },

--- a/src/components/Sidebar/SortableDropdownList.tsx
+++ b/src/components/Sidebar/SortableDropdownList.tsx
@@ -11,7 +11,7 @@ import {
 import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import React, { useState } from 'react';
 import SortableDropdown from './SortableDropdown';
-import type { Team } from './types';
+import type { Team } from '../../types/setting';
 
 interface SortableDropdownListProps {
   items: Team[];

--- a/src/components/Sidebar/types.ts
+++ b/src/components/Sidebar/types.ts
@@ -1,3 +1,0 @@
-import type { TeamListResponse } from '../../types/setting';
-
-export type Team = Pick<TeamListResponse, 'teamId' | 'name' | 'profileUrl'>;

--- a/src/pages/setting/SettingMember.tsx
+++ b/src/pages/setting/SettingMember.tsx
@@ -5,51 +5,51 @@ import MemberInviteModal from './components/modal/MemberInviteModal.tsx';
 
 const DUMMY_MEMBERS = [
   {
-    id: 1,
-    profileImage: 'https://avatars.githubusercontent.com/u/91470334?v=4',
+    memberId: 1,
+    profileImageUrl: 'https://avatars.githubusercontent.com/u/91470334?v=4',
     name: '이가을',
     email: 'gaeulzzang@gmail.com',
     teams: [
-      { id: 1, name: 'veco1', teamProfileImage: null },
+      { teamId: 1, teamName: 'veco1', teamImageUrl: null },
       {
-        id: 2,
-        name: 'veco2',
-        teamProfileImage: 'https://avatars.githubusercontent.com/u/91470334?v=4',
+        teamId: 2,
+        teamName: 'veco2',
+        teamImageUrl: 'https://avatars.githubusercontent.com/u/91470334?v=4',
       },
     ],
-    date: '25.01.01',
+    joinedAt: '25.01.01',
   },
   {
-    id: 2,
-    profileImage: null,
+    memberId: 2,
+    profileImageUrl: null,
     name: '선우정아',
     email: 'mymelody@naver.com',
     teams: [],
-    date: '25.02.01',
+    joinedAt: '25.02.01',
   },
   {
-    id: 3,
-    profileImage: null,
+    memberId: 3,
+    profileImageUrl: null,
     name: '가응가',
     email: 'gaeullee@gmail.com',
-    teams: [{ id: 1, name: 'veco1', teamProfileImage: null }],
-    date: '25.03.01',
+    teams: [{ teamId: 1, teamName: 'veco1', teamImageUrl: null }],
+    joinedAt: '25.03.01',
   },
   {
-    id: 4,
-    profileImage: null,
+    memberId: 4,
+    profileImageUrl: null,
     name: '가을리',
     email: 'gaeulzzang11@naver.com',
     teams: [
       {
-        id: 1,
-        name: 'veco1',
-        teamProfileImage: 'https://avatars.githubusercontent.com/u/91470334?v=4',
+        teamId: 1,
+        teamName: 'veco1',
+        teamImageUrl: 'https://avatars.githubusercontent.com/u/91470334?v=4',
       },
-      { id: 2, name: 'veco2', teamProfileImage: null },
-      { id: 3, name: 'veco3', teamProfileImage: null },
+      { teamId: 2, teamName: 'veco2', teamImageUrl: null },
+      { teamId: 3, teamName: 'veco3', teamImageUrl: null },
     ],
-    date: '25.04.01',
+    joinedAt: '25.04.01',
   },
 ];
 
@@ -66,22 +66,22 @@ const SettingMember = () => {
       />
       <hr className={`w-full text-gray-300`} />
       <MemberItem
-        profileImage={DUMMY_MEMBERS[0].profileImage}
+        profileImageUrl={DUMMY_MEMBERS[0].profileImageUrl}
         name={DUMMY_MEMBERS[0].name}
         email={DUMMY_MEMBERS[0].email}
         teams={DUMMY_MEMBERS[0].teams}
-        date={DUMMY_MEMBERS[0].date}
+        joinedAt={DUMMY_MEMBERS[0].joinedAt}
         className={`py-[2.4rem]`}
       />
       <hr className={`w-full text-gray-300 mb-[2.4rem]`} />
       {DUMMY_MEMBERS.slice(1).map((member, index) => (
         <MemberItem
           key={index}
-          profileImage={member.profileImage}
+          profileImageUrl={member.profileImageUrl}
           name={member.name}
           email={member.email}
           teams={member.teams}
-          date={member.date}
+          joinedAt={member.joinedAt}
           className={`mb-[3.2rem]`}
         />
       ))}

--- a/src/pages/setting/SettingTeam.tsx
+++ b/src/pages/setting/SettingTeam.tsx
@@ -5,30 +5,30 @@ import TeamCreateModal from './components/modal/TeamCreateModal.tsx';
 
 const DUMMY_TEAMS = [
   {
-    id: 1,
-    profileImage: 'https://avatars.githubusercontent.com/u/91470334?v=4',
-    name: 'Workspace',
+    teamId: 1,
+    teamImageUrl: 'https://avatars.githubusercontent.com/u/91470334?v=4',
+    teamName: 'Workspace',
     memberCount: 10,
     createdAt: '25.01.01',
   },
   {
-    id: 2,
-    profileImage: null,
-    name: 'Team A',
+    teamId: 2,
+    teamImageUrl: null,
+    teamName: 'Team A',
     memberCount: 5,
     createdAt: '25.02.01',
   },
   {
-    id: 3,
-    profileImage: null,
-    name: 'Team B',
+    teamId: 3,
+    teamImageUrl: null,
+    teamName: 'Team B',
     memberCount: 8,
     createdAt: '25.03.01',
   },
   {
-    id: 4,
-    profileImage: null,
-    name: 'Team C',
+    teamId: 4,
+    teamImageUrl: null,
+    teamName: 'Team C',
     memberCount: 3,
     createdAt: '25.04.01',
   },
@@ -47,8 +47,8 @@ const SettingTeam = () => {
       />
       <hr className={`w-full text-gray-300`} />
       <TeamItem
-        profileImage={DUMMY_TEAMS[0].profileImage}
-        name={DUMMY_TEAMS[0].name}
+        teamImageUrl={DUMMY_TEAMS[0].teamImageUrl}
+        teamName={DUMMY_TEAMS[0].teamName}
         memberCount={DUMMY_TEAMS[0].memberCount}
         createdAt={DUMMY_TEAMS[0].createdAt}
         className={`py-[2.4rem]`}
@@ -56,9 +56,9 @@ const SettingTeam = () => {
       <hr className={`w-full text-gray-300 mb-[2.4rem]`} />
       {DUMMY_TEAMS.slice(1).map((team, index) => (
         <TeamItem
-          profileImage={team.profileImage}
+          teamImageUrl={team.teamImageUrl}
           key={index}
-          name={team.name}
+          teamName={team.teamName}
           memberCount={team.memberCount}
           createdAt={team.createdAt}
           className={`mb-[3.2rem]`}

--- a/src/pages/setting/SettingWorkspaceProfile.tsx
+++ b/src/pages/setting/SettingWorkspaceProfile.tsx
@@ -6,7 +6,8 @@ const SettingWorkspaceProfile = () => {
   // TODO: 워크스페이스 프로필 조회 API 호출
   // const { data: workspaceData } = useGetWorkspaceProfile();
   const workspaceData = {
-    name: 'Veco',
+    workspaceName: 'Veco',
+    workspaceImageUrl: '',
     workspaceUrl: 'veco.app/veco',
   };
 
@@ -21,11 +22,19 @@ const SettingWorkspaceProfile = () => {
               <h2 className="font-title-sub-r text-gray-600">워크스페이스 로고</h2>
 
               <button className="w-[4.2rem] h-[4.2rem] flex items-center justify-center">
-                <img src={vecocirclenavy} className="w-full h-full" alt="프로필 사진" />
+                <img
+                  src={workspaceData?.workspaceImageUrl || vecocirclenavy}
+                  className="w-full h-full"
+                  alt="프로필 사진"
+                />
               </button>
             </section>
             <div className="flex flex-col gap-[3.2rem]">
-              <InputSection label="이름" placeholder={workspaceData?.name || 'Veco'} disabled />
+              <InputSection
+                label="이름"
+                placeholder={workspaceData?.workspaceName || 'Veco'}
+                disabled
+              />
               <InputSection
                 label="URL"
                 placeholder={workspaceData?.workspaceUrl || 'veco.app/veco'}

--- a/src/pages/setting/components/MemberItem.tsx
+++ b/src/pages/setting/components/MemberItem.tsx
@@ -5,17 +5,17 @@ import { useDropdownActions, useDropdownInfo } from '../../../hooks/useDropdown.
 import Dropdown from '../../../components/Dropdown/Dropdown.tsx';
 
 type SettingMemberTeam = {
-  id: number;
-  name: string;
-  teamProfileImage: string | null;
+  teamId: number;
+  teamName: string;
+  teamImageUrl: string | null;
 };
 
 interface MemberItemProps {
-  profileImage: string | null;
+  profileImageUrl: string | null;
   name: string;
   email: string;
   teams?: SettingMemberTeam[];
-  date: string;
+  joinedAt: string;
   className?: string;
 }
 
@@ -27,7 +27,7 @@ const MemberItem = (props: MemberItemProps) => {
     <div
       className={`flex w-full items-center text-gray-600 font-body-r ps-[4.3rem] pe-[4.9rem] whitespace-nowrap ${props.className}`}
     >
-      <ProfileImage profileImage={props.profileImage} className={'p-[0.4rem]'} />
+      <ProfileImage profileImage={props.profileImageUrl} className={'p-[0.4rem]'} />
       <span className={`ms-[4.1rem] text-start w-[6.4rem] truncate`}>{props.name}</span>
       <span className={`flex-1 ms-[2.8rem] text-start truncate`}>{props.email}</span>
       <div className={`flex gap-x-[1.8rem]`}>
@@ -35,7 +35,7 @@ const MemberItem = (props: MemberItemProps) => {
           <ProfileLayout teams={props.teams} onClick={() => openDropdown({ name: props.name })} />
           {isOpen && content?.name == props.name && (
             <Dropdown
-              options={props.teams?.map((team) => team.name) || []}
+              options={props.teams?.map((team) => team.teamName) || []}
               onSelect={() => {}}
               onClose={closeDropdown}
               className={`right-0 top-[2.4rem]`}
@@ -44,7 +44,7 @@ const MemberItem = (props: MemberItemProps) => {
         </section>
         <div className={`flex gap-x-[0.8rem] items-center`}>
           <img src={IcDate} alt={'생성일'} />
-          <span className={`truncate`}>{props.date}</span>
+          <span className={`truncate`}>{props.joinedAt}</span>
         </div>
       </div>
     </div>
@@ -60,17 +60,17 @@ const ProfileLayout = ({
 }) => {
   return (
     <div className={`flex w-[6.2rem] justify-start items-center`} onClick={onClick}>
-      {teams && teams.length === 1 && <ProfileImage profileImage={teams[0].teamProfileImage} />}
+      {teams && teams.length === 1 && <ProfileImage profileImage={teams[0].teamImageUrl} />}
       {teams && teams.length === 2 && (
         <div className={`flex relative items-center`}>
-          <ProfileImage profileImage={teams[0].teamProfileImage} />
-          <SubProfileImage profileImage={teams[1].teamProfileImage} />
+          <ProfileImage profileImage={teams[0].teamImageUrl} />
+          <SubProfileImage profileImage={teams[1].teamImageUrl} />
         </div>
       )}
       {teams && teams.length >= 3 && (
         <div className={`flex relative items-center`}>
-          <ProfileImage profileImage={teams[0].teamProfileImage} />
-          <SubProfileImage profileImage={teams[1].teamProfileImage} />
+          <ProfileImage profileImage={teams[0].teamImageUrl} />
+          <SubProfileImage profileImage={teams[1].teamImageUrl} />
           <span className="ms-[0.8rem] text-gray-600 font-body-r me-[0.86rem]">...</span>
         </div>
       )}

--- a/src/pages/setting/components/TeamItem.tsx
+++ b/src/pages/setting/components/TeamItem.tsx
@@ -3,8 +3,8 @@ import IcDate from '../../../assets/icons/date.svg';
 import ProfileImage from './ProfileImage.tsx';
 
 interface TeamItemProps {
-  profileImage: string | null;
-  name: string;
+  teamImageUrl: string | null;
+  teamName: string;
   memberCount: number;
   createdAt: string;
   className?: string;
@@ -15,8 +15,8 @@ const TeamItem = (props: TeamItemProps) => {
     <div
       className={`flex w-full items-center text-gray-600 font-body-r ps-[4.3rem] pe-[4.9rem] whitespace-nowrap ${props.className}`}
     >
-      <ProfileImage profileImage={props.profileImage} className={`p-[0.4rem]`} />
-      <span className={`flex-1 text-start ms-[3.9rem] truncate`}>{props.name}</span>
+      <ProfileImage profileImage={props.teamImageUrl} className={`p-[0.4rem]`} />
+      <span className={`flex-1 text-start ms-[3.9rem] truncate`}>{props.teamName}</span>
       <div className={`flex gap-x-[2.8rem]`}>
         <div className={`flex gap-x-[0.8rem] items-center`}>
           <img src={IcUserSearch} alt={'멤버 수'} />

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -1,7 +1,7 @@
 export type TeamListResponse = {
   teamId: number;
-  name: string;
-  profileUrl: string;
+  teamName: string;
+  teamImageUrl: string;
   memberCount: number;
   createdAt: string;
 };
@@ -10,7 +10,7 @@ export type MemberListResponse = {
   memberId: number;
   email: string;
   name: string;
-  profileUrl: string;
+  profileImageUrl: string;
   teams: Team[];
 };
 
@@ -23,30 +23,30 @@ export type TeamCreateResponse = {
 export type Team = {
   teamId: number;
   teamName: string;
-  teamProfileUrl: string;
+  teamImageUrl: string;
 };
 
 export type Member = {
   memberId: number;
-  memberName: string;
+  name: string;
 };
 
-export type Workspace = {
+export type WorkspaceResponse = {
   workspaceId: number;
-  name: string;
-  profileUrl: string;
+  workspaceName: string;
+  workspaceImageUrl: string;
   workspaceUrl: string;
   defaultTeamId: number;
 };
 
-export type MyProfile = {
+export type MyProfileResponse = {
   memberId: number;
   name: string;
   email: string;
-  profileImage: string;
+  profileImageUrl: string;
 };
 
-export type MyProfileImage = {
+export type MyProfileImageResponse = {
   memberId: number;
-  imageUrl: string;
+  profileImageUrl: string;
 };


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #115

---

### ✅ Key Changes

- 세팅페이지 관련 응답 필드 또는 내부 변수에서 name / teamName, imageUrl / profileImage 등 동일한 개념을 가리키는 용어가 혼용되어 필드명을 통일하였습니다.

- name 관련 변경사항
  - member -> name
  - team -> teamName
  - workspace -> workspaceName

- 프로필 이미지 관련 변경사항
  - member -> profileImageUrl
  - team -> teamImageUrl
  - workspace -> workspaceImageUrl

---

### 💬 To Reviewers
- 변경 후 npm run dev로 기존 세팅 페이지들이 정상 실행되는 것을 확인했습니다.
