### PR TITLE
[FEAT] 워크스페이스 URL 생성 & 워크스페이스 생성 API 연동

### DIFF
--- a/src/apis/workspace/usePostCreateWorkspace.ts
+++ b/src/apis/workspace/usePostCreateWorkspace.ts
@@ -25,6 +25,7 @@ export const usePostCreateWorkspace = () => {
       if (data.result) {
         localStorage.setItem(LOCAL_STORAGE_KEY.inviteUrl, data.result.inviteUrl);
         localStorage.setItem(LOCAL_STORAGE_KEY.invitePassword, data.result.invitePassWord);
+        localStorage.setItem(LOCAL_STORAGE_KEY.name, data.result.name);
       }
     },
   });

--- a/src/apis/workspace/usePostCreateWorkspace.ts
+++ b/src/apis/workspace/usePostCreateWorkspace.ts
@@ -24,7 +24,7 @@ export const usePostCreateWorkspace = () => {
     onSuccess: (data) => {
       if (data.result) {
         localStorage.setItem(LOCAL_STORAGE_KEY.inviteUrl, data.result.inviteUrl);
-        localStorage.setItem(LOCAL_STORAGE_KEY.invitePassword, data.result.invitePassWord);
+        localStorage.setItem(LOCAL_STORAGE_KEY.invitePassword, data.result.invitePassword);
         localStorage.setItem(LOCAL_STORAGE_KEY.name, data.result.name);
       }
     },

--- a/src/components/Onboarding/WorkspaceNameInput.tsx
+++ b/src/components/Onboarding/WorkspaceNameInput.tsx
@@ -5,13 +5,19 @@ import { usePostCreateWorkspaceUrl } from '../../apis/workspace/usePostCreateWor
 
 // 부모 컴포넌트에서 전달되는 props 타입 정의
 interface WorkspaceNameInputProps {
-  onUrlGenerated: (url: string) => void; // 생성된 URL을 상위 컴포넌트에 전달
+  setWorkspaceName: (url: string) => void; // 생성된 URL을 상위 컴포넌트에 전달
+  setWorkspaceUrl: (url: string) => void; // 생성된 URL을 상위 컴포넌트에 전달
+  workspaceUrl: string;
+  workspaceName: string;
 }
 
 // 워크스페이스 이름 입력 및 URL 생성 컴포넌트
-const WorkspaceNameInput = ({ onUrlGenerated }: WorkspaceNameInputProps) => {
-  const [workspaceName, setWorkspaceName] = useState(''); // 사용자가 입력한 워크스페이스 이름
-  const [workspaceUrl, setWorkspaceUrl] = useState(''); // 백엔드에서 생성된 URL
+const WorkspaceNameInput = ({
+  setWorkspaceName,
+  setWorkspaceUrl,
+  workspaceUrl,
+  workspaceName,
+}: WorkspaceNameInputProps) => {
   const [error, setError] = useState(''); // 유효성 검사 또는 서버 에러 메시지
 
   // react-query mutation 훅 사용
@@ -26,7 +32,7 @@ const WorkspaceNameInput = ({ onUrlGenerated }: WorkspaceNameInputProps) => {
     if (validationError) {
       setError(validationError);
       setWorkspaceUrl('');
-      onUrlGenerated('');
+      setWorkspaceName('');
       return;
     }
 
@@ -39,7 +45,7 @@ const WorkspaceNameInput = ({ onUrlGenerated }: WorkspaceNameInputProps) => {
     // 에러 초기화 및 상태 업데이트
     setError('');
     setWorkspaceUrl(url);
-    onUrlGenerated(url);
+    setWorkspaceName('');
   };
 
   return (

--- a/src/components/Onboarding/WorkspaceNameInput.tsx
+++ b/src/components/Onboarding/WorkspaceNameInput.tsx
@@ -45,7 +45,7 @@ const WorkspaceNameInput = ({
     // 에러 초기화 및 상태 업데이트
     setError('');
     setWorkspaceUrl(url);
-    setWorkspaceName('');
+    setWorkspaceName(workspaceName);
   };
 
   return (

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -2,4 +2,5 @@ export const LOCAL_STORAGE_KEY = {
   accessToken: 'accessToken',
   inviteUrl: 'inviteUrl',
   invitePassword: 'invitePassword',
+  name: 'name',
 };

--- a/src/pages/onboarding/OnboardingCreateWorkspace.tsx
+++ b/src/pages/onboarding/OnboardingCreateWorkspace.tsx
@@ -8,6 +8,7 @@ import WorkspaceNameInput from '../../components/Onboarding/WorkspaceNameInput';
 import { postReIssueAccessToken } from '../../apis/auth';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { LOCAL_STORAGE_KEY } from '../../constants/key';
+import { usePostCreateWorkspace } from '../../apis/workspace/usePostCreateWorkspace';
 
 const OnboardingCreateWorkspace = () => {
   // useOnboardingGuard(1); API 연결 후 훅 사용 예정
@@ -22,6 +23,8 @@ const OnboardingCreateWorkspace = () => {
     };
     fetchAccessToken();
   }, []);
+
+  const handleButtonClick = () => {};
 
   return (
     <div className="flex flex-col items-center gap-[3.2rem]">
@@ -48,7 +51,7 @@ const OnboardingCreateWorkspace = () => {
         <PrimaryButton
           text="워크스페이스 생성하기"
           disabled={!workspaceUrl}
-          to="/onboarding/invite"
+          onClick={handleButtonClick}
         />
       </div>
     </div>

--- a/src/pages/onboarding/OnboardingCreateWorkspace.tsx
+++ b/src/pages/onboarding/OnboardingCreateWorkspace.tsx
@@ -9,11 +9,13 @@ import { postReIssueAccessToken } from '../../apis/auth';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { LOCAL_STORAGE_KEY } from '../../constants/key';
 import { usePostCreateWorkspace } from '../../apis/workspace/usePostCreateWorkspace';
+import { useNavigate } from 'react-router-dom';
 
 const OnboardingCreateWorkspace = () => {
   // useOnboardingGuard(1); API 연결 후 훅 사용 예정
   const [workspaceName, setWorkspaceName] = useState('');
   const [workspaceUrl, setWorkspaceUrl] = useState('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchAccessToken = async () => {
@@ -24,7 +26,17 @@ const OnboardingCreateWorkspace = () => {
     fetchAccessToken();
   }, []);
 
-  const handleButtonClick = () => {};
+  const { mutateAsync } = usePostCreateWorkspace();
+
+  const handleButtonClick = async () => {
+    try {
+      const res = await mutateAsync({ workspaceName: workspaceName });
+      console.log(res);
+      navigate('/onboarding/invite');
+    } catch (error) {
+      console.error('에러 발생:', error);
+    }
+  };
 
   return (
     <div className="flex flex-col items-center gap-[3.2rem]">

--- a/src/pages/onboarding/OnboardingCreateWorkspace.tsx
+++ b/src/pages/onboarding/OnboardingCreateWorkspace.tsx
@@ -11,6 +11,7 @@ import { LOCAL_STORAGE_KEY } from '../../constants/key';
 
 const OnboardingCreateWorkspace = () => {
   // useOnboardingGuard(1); API 연결 후 훅 사용 예정
+  const [workspaceName, setWorkspaceName] = useState('');
   const [workspaceUrl, setWorkspaceUrl] = useState('');
 
   useEffect(() => {
@@ -36,7 +37,12 @@ const OnboardingCreateWorkspace = () => {
         </div>
 
         {/* 워크스페이스 이름 & 워크스페이스 URL */}
-        <WorkspaceNameInput onUrlGenerated={setWorkspaceUrl} />
+        <WorkspaceNameInput
+          setWorkspaceName={setWorkspaceName}
+          setWorkspaceUrl={setWorkspaceUrl}
+          workspaceUrl={workspaceUrl}
+          workspaceName={workspaceName}
+        />
 
         {/* 워크스페이스 생성하기 버튼 */}
         <PrimaryButton

--- a/src/pages/onboarding/OnboardingInviteMember.tsx
+++ b/src/pages/onboarding/OnboardingInviteMember.tsx
@@ -5,6 +5,7 @@ import CopyToClipboard from '../../components/Onboarding/CopyToClipboard';
 import PageIndicator from '../../components/Onboarding/PageIndicator';
 import onboardingSteps from '../../constants/onboardingSteps';
 import PrimaryButton from '../../components/Onboarding/PrimaryButton';
+import { LOCAL_STORAGE_KEY } from '../../constants/key';
 
 const OnboardingInviteMember = () => {
   // useOnboardingGuard(2); API 연결 후 훅 사용 예정
@@ -18,7 +19,7 @@ const OnboardingInviteMember = () => {
   // 임시로 하드코딩된 초대 정보 세팅
   useEffect(() => {
     setInviteText(
-      `팀원 URL : https://veco-eight.vercel.app/{slug}/invite?token=abcd1234\n\n암호 : aK39Gp`
+      `팀원 URL : ${localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl)}\n\n암호 : ${localStorage.getItem(LOCAL_STORAGE_KEY.invitePassword)}`
     );
   }, []);
 
@@ -32,7 +33,9 @@ const OnboardingInviteMember = () => {
           {/* 초대 문구 */}
           <div className="flex flex-col text-center gap-[1rem]">
             <h1 className="font-bigtitle-b text-primary-blue">팀원 초대</h1>
-            <p className="font-title-sub-r text-gray-600">팀원을 OO님의 팀에 초대해봐요</p>
+            <p className="font-title-sub-r text-gray-600">
+              팀원을 {localStorage.getItem(LOCAL_STORAGE_KEY.name)}님의 팀에 초대해봐요
+            </p>
             {/* 백엔드 연동 후 사용자 이름을 동적으로 바인딩 할 것 */}
           </div>
           <div className="flex items-start gap-[1rem]">

--- a/src/pages/onboarding/OnboardingInviteMember.tsx
+++ b/src/pages/onboarding/OnboardingInviteMember.tsx
@@ -16,7 +16,6 @@ const OnboardingInviteMember = () => {
   // 텍스트 영역의 DOM 요소에 접근하기 위한 ref (복사 기능용)
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  // 임시로 하드코딩된 초대 정보 세팅
   useEffect(() => {
     setInviteText(
       `팀원 URL : ${localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl)}\n\n암호 : ${localStorage.getItem(LOCAL_STORAGE_KEY.invitePassword)}`
@@ -36,7 +35,6 @@ const OnboardingInviteMember = () => {
             <p className="font-title-sub-r text-gray-600">
               팀원을 {localStorage.getItem(LOCAL_STORAGE_KEY.name)}님의 팀에 초대해봐요
             </p>
-            {/* 백엔드 연동 후 사용자 이름을 동적으로 바인딩 할 것 */}
           </div>
           <div className="flex items-start gap-[1rem]">
             {/* 입력창 */}

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -11,7 +11,7 @@ export type CreateWorkspaceResponse = CommonResponse<{
   workspaceName: string;
   workspaceUrl: string;
   inviteUrl: string;
-  invitePassWord: string;
+  invitePassword: string;
   defaultTeamId: number;
 }>;
 

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -7,6 +7,7 @@ export interface CreateWorkspaceRequest {
 
 export type CreateWorkspaceResponse = CommonResponse<{
   workspaceId: number;
+  name: string;
   workspaceName: string;
   workspaceUrl: string;
   inviteUrl: string;


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #121 

---

### ✅ Key Changes

- 워크스페이스 URL 생성  & 워크스페이스 생성 연동했습니다.
- 하드코딩된 정보가 본인의 이름과 팀원 초대 URL, 암호로 제대로 보여집니다.
---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
- 계정 하나당 하나의 워크스페이스를 생성할 수 있기 때문에  처음에 실행할 때 딱 한 번만 테스트 가능해서... 영상은 없습니다..
---

### 💬 To Reviewers
<!-- 팀원들에게 전달하고 싶은 말이나 노티해야되는 내용을 적어주세요. -->
- 아직 시도해보지 않은 분들은 https://web.vecoservice.shop/onboarding 여기서 구글로 계속하기 실행하시면 정상적으로 하나의 워크스페이스를 생성하실 수 있습니다.