### PR TITLE
[FEAT] 생성될 목표, 이슈, 외부 이름 api 연동 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,10 @@
         "react": "^19.1.0",
         "react-calendar": "^6.0.0",
         "react-dom": "^19.1.0",
+        "react-error-boundary": "^6.0.0",
         "react-intersection-observer": "^9.16.0",
         "react-router-dom": "^7.6.3",
+        "react-spinners": "^0.17.0",
         "tailwindcss": "^4.1.11",
         "zustand": "^5.0.6"
       },
@@ -300,6 +302,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1001,9 +1012,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5462,6 +5473,18 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-intersection-observer": {
       "version": "9.16.0",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
@@ -5530,6 +5553,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
+      "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "react": "^19.1.0",
     "react-calendar": "^6.0.0",
     "react-dom": "^19.1.0",
+    "react-error-boundary": "^6.0.0",
     "react-intersection-observer": "^9.16.0",
     "react-router-dom": "^7.6.3",
+    "react-spinners": "^0.17.0",
     "tailwindcss": "^4.1.11",
     "zustand": "^5.0.6"
   },

--- a/src/apis/external/useGetSlackConnect.ts
+++ b/src/apis/external/useGetSlackConnect.ts
@@ -7,12 +7,10 @@ interface GetSlackConnectResponse {
   linkedAt: string;
 }
 
-const getSlackConnect = async (workspaceId: number): Promise<GetSlackConnectResponse> => {
+const getSlackConnect = async (): Promise<GetSlackConnectResponse> => {
   try {
-    const response = await axiosInstance.get<CommonResponse<GetSlackConnectResponse>>(
-      '/slack/connect',
-      { params: workspaceId }
-    );
+    const response =
+      await axiosInstance.get<CommonResponse<GetSlackConnectResponse>>('/slack/connect');
     if (!response.data.result) return Promise.reject(response);
     return response.data.result;
   } catch (error) {
@@ -21,9 +19,9 @@ const getSlackConnect = async (workspaceId: number): Promise<GetSlackConnectResp
   }
 };
 
-export const useGetSlackConnect = (workspaceId: number) => {
+export const useGetSlackConnect = () => {
   return useMutation({
-    mutationFn: () => getSlackConnect(workspaceId),
+    mutationFn: () => getSlackConnect(),
     onSuccess: () => {
       console.log('Slack 연동 조회 성공');
     },

--- a/src/apis/setting/useGetWorkspaceMembers.ts
+++ b/src/apis/setting/useGetWorkspaceMembers.ts
@@ -1,7 +1,7 @@
 import type { MemberListResponse } from '../../types/setting.ts';
 import { axiosInstance } from '../axios.ts';
 import type { CommonResponse } from '../../types/common.ts';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey.ts';
 
 // 설정 - 워크스페이스 멤버 조회
@@ -19,7 +19,7 @@ const getWorkspaceMembers = async (): Promise<MemberListResponse[]> => {
 };
 
 export const useGetWorkspaceMembers = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: [queryKey.WORKSPACE_MEMBERS],
     queryFn: getWorkspaceMembers,
   });

--- a/src/components/DetailView/DetailHeader.tsx
+++ b/src/components/DetailView/DetailHeader.tsx
@@ -1,12 +1,8 @@
-// DetailHeader.tsx
-// 상세페이지 헤더 컴포넌트
-
-import { dummyStatusGoalGroups } from '../../types/testDummy';
 import TeamIcon from '../ListView/TeamIcon';
-// import { useGetGoalName } from '../../apis/goal/useGetGoalName.ts';
-// import { useGetExternalName } from '../../apis/external/useGetExternalName.ts';
-// import { useGetIssueName } from '../../apis/issue/useGetIssueName.ts';
-// import { useParams } from 'react-router-dom';
+import { useGetGoalName } from '../../apis/goal/useGetGoalName.ts';
+import { useGetExternalName } from '../../apis/external/useGetExternalName.ts';
+import { useGetIssueName } from '../../apis/issue/useGetIssueName.ts';
+import { useParams } from 'react-router-dom';
 
 interface DetailHeaderProps {
   type: 'goal' | 'issue' | 'external';
@@ -15,23 +11,13 @@ interface DetailHeaderProps {
 }
 
 const DetailHeader = ({ type, defaultTitle, title }: DetailHeaderProps) => {
-  // 상세페이지의 ID 체계 : 일단 dummy 데이터 첫번째를 임의로 가져옴.
-  // 추후 실제 API 연결하면서 다시 작성할 예정
-  const groupIndex = 0;
-  const goalIndex = 0;
-  console.log(type);
-
-  // TODO: 추후 API 연결 시 아래 주석 해제
-  // const teamId = Number(useParams<{ teamId: string }>().teamId);
-  // const getDetailId =
-  //   type === 'goal'
-  //     ? useGetGoalName(teamId)
-  //     : type === 'issue'
-  //       ? useGetIssueName(teamId)
-  //       : useGetExternalName(teamId);
-  // console.log(getDetailId);
-
-  const detailId = dummyStatusGoalGroups[groupIndex]?.goals[goalIndex]?.name;
+  const teamId = Number(useParams<{ teamId: string }>().teamId);
+  const { data: detailId } =
+    type === 'goal'
+      ? useGetGoalName(teamId)
+      : type === 'issue'
+        ? useGetIssueName(teamId)
+        : useGetExternalName(teamId);
 
   return (
     <div className="flex gap-[3.2rem] flex-nowrap">

--- a/src/components/DetailView/WorkspaceDetailHeader.tsx
+++ b/src/components/DetailView/WorkspaceDetailHeader.tsx
@@ -1,20 +1,23 @@
-// WorkspaceDetailHeader.tsx
-// 워크스페이스 전체 팀 - 상세페이지 헤더 컴포넌트
-
-import { dummyStatusGoalGroups } from '../../types/testDummy';
 import WorkspaceIcon from '../ListView/WorkspaceIcon';
+import { useParams } from 'react-router-dom';
+import { useGetGoalName } from '../../apis/goal/useGetGoalName.ts';
+import { useGetIssueName } from '../../apis/issue/useGetIssueName.ts';
+import { useGetExternalName } from '../../apis/external/useGetExternalName.ts';
 
 interface WorkspaceDetailHeaderProps {
+  type: 'goal' | 'issue' | 'external';
   defaultTitle: string; // 상세페이지 제목에 아무것도 입력되지 않았을 때 기본 타이틀
   title: string; // 상세페이지 제목으로부터 전달받아올 타이틀
 }
 
-const WorkspaceDetailHeader = ({ defaultTitle, title }: WorkspaceDetailHeaderProps) => {
-  // 상세페이지의 ID 체계 : 일단 dummy 데이터 첫번째를 임의로 가져옴.
-  // 추후 실제 API 연결하면서 다시 작성할 예정
-  const groupIndex = 0;
-  const goalIndex = 0;
-  const detailId = dummyStatusGoalGroups[groupIndex]?.goals[goalIndex]?.name;
+const WorkspaceDetailHeader = ({ type, defaultTitle, title }: WorkspaceDetailHeaderProps) => {
+  const teamId = Number(useParams<{ teamId: string }>().teamId);
+  const { data: detailId } =
+    type === 'goal'
+      ? useGetGoalName(teamId)
+      : type === 'issue'
+        ? useGetIssueName(teamId)
+        : useGetExternalName(teamId);
 
   return (
     <div className="flex gap-[3.2rem] flex-nowrap">

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -1,19 +1,32 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from '../components/Sidebar/Sidebar';
 import SettingSidebar from '../components/Sidebar/SettingSidebar';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import Loading from '../pages/Loading.tsx';
+import Error from '../pages/Error.tsx';
 
 const ProtectedLayout = () => {
   const location = useLocation();
   const isSettingRoute = location.pathname.startsWith('/workspace/setting');
   return (
-    <div className="flex h-screen">
-      <aside className="overflow-auto sidebar-scroll">
-        {isSettingRoute ? <SettingSidebar /> : <Sidebar />}
-      </aside>
-      <main className="flex flex-1 min-w-0 overflow-auto basic-scroll">
-        <Outlet />
-      </main>
-    </div>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} FallbackComponent={Error}>
+          <Suspense fallback={<Loading />}>
+            <div className="flex h-screen">
+              <aside className="overflow-auto sidebar-scroll">
+                {isSettingRoute ? <SettingSidebar /> : <Sidebar />}
+              </aside>
+              <main className="flex flex-1 min-w-0 overflow-auto basic-scroll">
+                <Outlet />
+              </main>
+            </div>
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 };
 

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -5,7 +5,7 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import Loading from '../pages/Loading.tsx';
-import Error from '../pages/Error.tsx';
+import Server500Error from '../pages/Server500Error.tsx';
 
 const ProtectedLayout = () => {
   const location = useLocation();
@@ -13,7 +13,7 @@ const ProtectedLayout = () => {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary onReset={reset} FallbackComponent={Error}>
+        <ErrorBoundary onReset={reset} FallbackComponent={Server500Error}>
           <Suspense fallback={<Loading />}>
             <div className="flex h-screen">
               <aside className="overflow-auto sidebar-scroll">

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
-import Error from '../pages/Error.tsx';
+import Server500Error from '../pages/Server500Error.tsx';
 import { Suspense } from 'react';
 import Loading from '../pages/Loading.tsx';
 
@@ -9,7 +9,7 @@ const PublicLayout = () => {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary onReset={reset} FallbackComponent={Error}>
+        <ErrorBoundary onReset={reset} FallbackComponent={Server500Error}>
           <Suspense fallback={<Loading />}>
             <main className="w-full h-screen overflow-auto basic-scroll bg-gray-onboard">
               <div className="min-w-max min-h-screen flex flex-col items-center justify-center">

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -1,12 +1,25 @@
 import { Outlet } from 'react-router-dom';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
+import Error from '../pages/Error.tsx';
+import { Suspense } from 'react';
+import Loading from '../pages/Loading.tsx';
 
 const PublicLayout = () => {
   return (
-    <main className="w-full h-screen overflow-auto basic-scroll bg-gray-onboard">
-      <div className="min-w-max min-h-screen flex flex-col items-center justify-center">
-        <Outlet />
-      </div>
-    </main>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} FallbackComponent={Error}>
+          <Suspense fallback={<Loading />}>
+            <main className="w-full h-screen overflow-auto basic-scroll bg-gray-onboard">
+              <div className="min-w-max min-h-screen flex flex-col items-center justify-center">
+                <Outlet />
+              </div>
+            </main>
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 };
 

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -1,0 +1,27 @@
+import { useNavigate } from 'react-router-dom';
+import PrimaryButton from '../components/Onboarding/PrimaryButton.tsx';
+
+const Error = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col w-full items-center justify-center bg-gray-onboard">
+      <div className="h-[42rem] flex flex-col justify-end">
+        <div className="flex flex-col items-center gap-[10.8rem]">
+          {/* 에러 문구 */}
+          <div className="flex flex-col gap-[3.2rem] text-center">
+            <h2 className="font-bigtitle-b text-gray-600">500</h2>
+            <h3 className="font-title-sub-r text-gray-600">
+              서버 오류가 발생했습니다.
+              <br /> 잠시 후 다시 시도해 주세요!
+            </h3>
+          </div>
+          {/* 돌아가기 버튼 */}
+          <PrimaryButton text="돌아가기" onClick={() => navigate(-1)} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -5,7 +5,7 @@ const Error = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="flex flex-col w-full items-center justify-center bg-gray-onboard">
+    <div className="flex flex-col w-full h-dvh items-center justify-center bg-gray-onboard">
       <div className="h-[42rem] flex flex-col justify-end">
         <div className="flex flex-col items-center gap-[10.8rem]">
           {/* 에러 문구 */}
@@ -17,7 +17,13 @@ const Error = () => {
             </h3>
           </div>
           {/* 돌아가기 버튼 */}
-          <PrimaryButton text="돌아가기" onClick={() => navigate(-1)} />
+          <PrimaryButton
+            text="돌아가기"
+            onClick={() => {
+              navigate(-1);
+              window.location.reload();
+            }}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/Loading.tsx
+++ b/src/pages/Loading.tsx
@@ -1,0 +1,11 @@
+import { ClipLoader } from 'react-spinners';
+
+const Loading = () => {
+  return (
+    <div className={`flex justify-center items-center w-full h-dvh`}>
+      <ClipLoader color={'#132650'} />
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/pages/Server500Error.tsx
+++ b/src/pages/Server500Error.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import PrimaryButton from '../components/Onboarding/PrimaryButton.tsx';
 
-const Error = () => {
+const Server500Error = () => {
   const navigate = useNavigate();
 
   return (
@@ -30,4 +30,4 @@ const Error = () => {
   );
 };
 
-export default Error;
+export default Server500Error;

--- a/src/pages/external/components/ExternalToolModal.tsx
+++ b/src/pages/external/components/ExternalToolModal.tsx
@@ -4,7 +4,6 @@ import GithubIcon from '../../../assets/icons/github.svg';
 import GithubWhiteIcon from '../../../assets/icons/github-white.svg';
 import SlackIcon from '../../../assets/icons/slack.svg';
 import ExternalToolButton from './ExternalToolButton';
-import { useGetWorkspaceProfile } from '../../../apis/setting/useGetWorkspaceProfile.ts';
 import { useParams } from 'react-router-dom';
 import { useGetGithubConnect } from '../../../apis/external/useGetGithubConnect.ts';
 import { useGetSlackConnect } from '../../../apis/external/useGetSlackConnect.ts';
@@ -39,8 +38,7 @@ interface ExternalToolModalProps {
 const ExternalToolModal = ({ onClose }: ExternalToolModalProps) => {
   const teamId = Number(useParams().teamId);
   const { mutate: connectGithub } = useGetGithubConnect(teamId);
-  const workspaceId = useGetWorkspaceProfile().data?.workspaceId || 0;
-  const { mutate: connectSlack } = useGetSlackConnect(workspaceId);
+  const { mutate: connectSlack } = useGetSlackConnect();
   const [selected, setSelected] = useState<string | null>(null);
 
   return createPortal(

--- a/src/pages/external/components/ExternalToolModal.tsx
+++ b/src/pages/external/components/ExternalToolModal.tsx
@@ -4,10 +4,10 @@ import GithubIcon from '../../../assets/icons/github.svg';
 import GithubWhiteIcon from '../../../assets/icons/github-white.svg';
 import SlackIcon from '../../../assets/icons/slack.svg';
 import ExternalToolButton from './ExternalToolButton';
-// import { useGetWorkspaceProfile } from '../../../apis/setting/useGetWorkspaceProfile.ts';
-// import { useParams } from 'react-router-dom';
-// import { useGetGithubConnect } from '../../../apis/external/useGetGithubConnect.ts';
-// import { useGetSlackConnect } from '../../../apis/external/useGetSlackConnect.ts';
+import { useGetWorkspaceProfile } from '../../../apis/setting/useGetWorkspaceProfile.ts';
+import { useParams } from 'react-router-dom';
+import { useGetGithubConnect } from '../../../apis/external/useGetGithubConnect.ts';
+import { useGetSlackConnect } from '../../../apis/external/useGetSlackConnect.ts';
 
 const TOOL_LIST = [
   {
@@ -37,11 +37,10 @@ interface ExternalToolModalProps {
 }
 
 const ExternalToolModal = ({ onClose }: ExternalToolModalProps) => {
-  // TODO: 외부 연동 API 호출 시 주석 해제
-  // const teamId = Number(useParams().teamId);
-  // const { mutate: connectGithub } = useGetGithubConnect(teamId);
-  // const workspaceId = useGetWorkspaceProfile().data?.workspaceId || 0;
-  // const { mutate: connectSlack } = useGetSlackConnect(workspaceId);
+  const teamId = Number(useParams().teamId);
+  const { mutate: connectGithub } = useGetGithubConnect(teamId);
+  const workspaceId = useGetWorkspaceProfile().data?.workspaceId || 0;
+  const { mutate: connectSlack } = useGetSlackConnect(workspaceId);
   const [selected, setSelected] = useState<string | null>(null);
 
   return createPortal(
@@ -77,9 +76,9 @@ const ExternalToolModal = ({ onClose }: ExternalToolModalProps) => {
           `}
           onClick={() => {
             if (selected === 'SLACK') {
-              // connectSlack();
+              connectSlack();
             } else if (selected === 'GITHUB') {
-              // connectGithub();
+              connectGithub();
             }
             onClose();
           }}

--- a/src/pages/setting/SettingTeam.tsx
+++ b/src/pages/setting/SettingTeam.tsx
@@ -35,7 +35,10 @@ const SettingTeam = () => {
       />
       <hr className={`w-full text-gray-300`} />
       {isLoading ? (
-        <TeamItemSkeleton />
+        <>
+          <TeamItemSkeleton />
+          <TeamItemSkeleton />
+        </>
       ) : (
         <>
           {firstTeam && (

--- a/src/pages/setting/components/TeamItemSkeleton.tsx
+++ b/src/pages/setting/components/TeamItemSkeleton.tsx
@@ -1,6 +1,6 @@
 const TeamItemSkeleton = () => {
   return (
-    <div className="flex items-center mb-[3.2rem] animate-pulse">
+    <div className="flex items-center animate-pulse p-[2.4rem]">
       <div className="w-12 h-12 bg-gray-200 rounded-full mr-4" />
       <div className="flex-1">
         <div className="h-4 bg-gray-200 rounded w-1/3 mb-2" />

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -82,7 +82,7 @@ const WorkspaceExternalDetail = () => {
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
-      <WorkspaceDetailHeader defaultTitle="제목을 작성해보세요" title={title} />
+      <WorkspaceDetailHeader type={'external'} defaultTitle="제목을 작성해보세요" title={title} />
 
       {/* 상세페이지 메인 */}
       <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -72,7 +72,7 @@ const WorkspaceGoalDetail = () => {
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
-      <WorkspaceDetailHeader defaultTitle="목표를 생성하세요" title={title} />
+      <WorkspaceDetailHeader type={'goal'} defaultTitle="목표를 생성하세요" title={title} />
 
       {/* 상세페이지 메인 */}
       <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -74,7 +74,7 @@ const WorkspaceIssueDetail = () => {
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
-      <WorkspaceDetailHeader defaultTitle="이슈를 생성하세요" title={title} />
+      <WorkspaceDetailHeader type={'issue'} defaultTitle="이슈를 생성하세요" title={title} />
 
       {/* 상세페이지 메인 */}
       <div className="flex px-[3.2rem] gap-[8.8rem] w-full h-full">


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #126 

---

### ✅ Key Changes

- 500 페이지 제작 -> Error.tsx
- 로딩 페이지 제작 -> Loading.tsx
- 생성될 외부, 이슈, 목표 이름 api 연동
- QueryErrorResetBoundary로 로딩, 에러 처리

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
서버가 잠시 죽어 있어서 스크린샷은 첨부하지 못했지만, 정상적으로 동작하는거 확인했습니다~

---

### 💬 To Reviewers
<!-- 팀원들에게 전달하고 싶은 말이나 노티해야되는 내용을 적어주세요. -->
기존의 useQuery를 useSuspenseQuery로 변경하면 API 호출 시 일관된 로딩/에러 UI 처리가 가능해집니다.
Layout을 모두 QueryErrorResetBoundary와 Suspense로 감싸 공통 로딩/에러 페이지(Loading.tsx, Error.tsx)가 자동으로 노출되도록 구현했습니다.
API 호출하실 때는 useSuspenseQuery 사용을 권장드립니다 🙌
@vecosystem/veco_frontend 