### PR TITLE
[FIX] 상세페이지 500 error 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/apis/external/useGetExternalName.ts
+++ b/src/apis/external/useGetExternalName.ts
@@ -7,7 +7,7 @@ import { queryKey } from '../../constants/queryKey.ts';
 const getExternalName = async (teamId: number): Promise<string> => {
   try {
     const response = await axiosInstance.get<CommonResponse<string>>(
-      `/api/teams/${teamId}/external-name`
+      `/api/teams/${teamId}/externals/external-name`
     );
     if (!response.data.result) return Promise.reject(response);
     return response.data.result;

--- a/src/pages/workspace/WorkspaceExternal.tsx
+++ b/src/pages/workspace/WorkspaceExternal.tsx
@@ -182,7 +182,9 @@ const WorkspaceExternal = () => {
                       checked={checkItems.includes(externals.id)}
                       onCheckChange={(checked) => handleCheck(externals.id, checked)}
                       filter={filter}
-                      onItemClick={() => navigate(`/workspace/team/${teamId}/ext/${externals.id}`)}
+                      onItemClick={() =>
+                        navigate(`/workspace/default/team/${teamId}/ext/${externals.id}`)
+                      }
                     />
                   ))}
                 </div>

--- a/src/pages/workspace/WorkspaceGoal.tsx
+++ b/src/pages/workspace/WorkspaceGoal.tsx
@@ -164,7 +164,9 @@ const WorkspaceGoal = () => {
                       checked={checkItems.includes(goal.id)}
                       onCheckChange={(checked) => handleCheck(goal.id, checked)}
                       filter={filter}
-                      onItemClick={() => navigate(`/workspace/team/${teamId}/ext/${goal.id}`)}
+                      onItemClick={() =>
+                        navigate(`/workspace/default/team/${teamId}/goal/${goal.id}`)
+                      }
                     />
                   ))}
                 </div>

--- a/src/pages/workspace/WorkspaceIssue.tsx
+++ b/src/pages/workspace/WorkspaceIssue.tsx
@@ -168,7 +168,9 @@ const WorkspaceIssue = () => {
                       checked={checkItems.includes(issue.id)}
                       onCheckChange={(checked) => handleCheck(issue.id, checked)}
                       filter={filter}
-                      onItemClick={() => navigate(`/workspace/team/${teamId}/ext/${issue.id}`)}
+                      onItemClick={() =>
+                        navigate(`/workspace/default/team/${teamId}/issue/${issue.id}`)
+                      }
                     />
                   ))}
                 </div>


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #131 

---

### ✅ Key Changes
**개발서버 환경의 워크스페이스에서 상세페이지 진입시 발생하는 500 에러의 원인을 파악하고 수정했습니다.**
<br>

**1) 워크스페이스 전체 팀 목록 페이지에서 연결되는 상세페이지 경로 오류로 인한 500 에러**
`WorkspaceGoal.tsx`, `WorkspaceExternal.tsx`, `WorkspaceIssue.tsx`에서 리스트의 개별 목표/외부/이슈 아이템들을 클릭시 navigate되는 상세페이지 url 모두 경로에 `/ext`가 포함되어 있어 외부 상세페이지가 호출되지만, 실제로 외부 API에 존재하지 않는 상세페이지 id와 조합되어있으므로 서버에서 500 에러를 반환한 것 같습니다.

=> 상세페이지로 연결되는 url 구조 모두 수정했습니다.

- 수정 전: `/workspace/team/${teamId}/ext/${externals.id}`
- 수정 후: `/workspace/default/team/${teamId}/ext/${externals.id}`
<br>

**2) 외부 이슈 이름 조회 시 호출하는 api 엔드포인트 오류**
외부이슈 상세페이지의 헤더 컴포넌트(`DetailHeader.tsx`)에서 호출된 `useGetExternalName.ts`의 함수에서 호출하는 api의 엔드포인트가 실제 개발용 스웨거 문서([링크](https://dev-vecoservice.shop/swagger-ui/index.html))와 달라서 에러가 발생했습니다.<br><br>

=> 아래와 같이 uri를 실제 스웨거상의 uri로 수정했습니다.

- 수정 전 uri: `/api/teams/${teamId}/external-name`
- 수정 후 uri: `/api/teams/${teamId}/externals/external-name`

---

### 📸 스크린샷 or 실행영상
위 2가지 사항 수정하니, console 탭에 500 에러가 더 이상 안 뜨는 것을 확인했습니다.
<br>
(1) 목표 상세페이지
<img width="1541" height="1153" alt="스크린샷 2025-08-06 오전 2 29 19" src="https://github.com/user-attachments/assets/ca1dba33-9451-465c-90b5-3c522d3e6904" />
<br>
(2) 이슈 상세페이지
<img width="1541" height="1153" alt="스크린샷 2025-08-06 오전 2 29 24" src="https://github.com/user-attachments/assets/1a31c475-760b-4d85-a56a-49bc68605e4d" />
<br>
(3) 외부 상세페이지
<img width="1541" height="1153" alt="스크린샷 2025-08-06 오전 2 29 27" src="https://github.com/user-attachments/assets/30ed4ff5-2538-4559-8e72-2cae5c803430" />



---

### 💬 To Reviewers

이 에러는 상세페이지 mode별 라우트 분리 작업보다 먼저 수정되어야 라우트 수정까지 진행할 수 있으므로 먼저 pr 날립니다.

그리고 해당 문제 해결을 위해 주헌님과 대화하다가 들은 건데, 스웨거 문서 링크도 새로 변경된 개발서버용 도메인과 동일하게 변경이 되었네요... 저만 몰랐을 수도 있지만 혹시나 싶어서 남겨둡니다.
**변경된 스웨거 문서 링크**: https://dev-vecoservice.shop/swagger-ui/index.html
