### PR TITLE
[FEAT] 팀 내 목표, 이슈 간단 조회 및 팀원 조회 API 세팅

### DIFF
--- a/src/apis/goal/useGetSimpleGoalList.ts.ts
+++ b/src/apis/goal/useGetSimpleGoalList.ts.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '../axios';
+import type { CommonResponse } from '../../types/common';
+import type { SimpleGoalListDto } from '../../types/goal';
+import { useQuery } from '@tanstack/react-query';
+import { queryKey } from '../../constants/queryKey';
+
+// 팀의 목표들을 간단 조회
+// 이슈, 외부에서 목표 연결시 사용
+const getSimpleGoalList = async (teamId: number): Promise<SimpleGoalListDto> => {
+  try {
+    const response = await axiosInstance.get<CommonResponse<SimpleGoalListDto>>(
+      `/api/teams/${teamId}/goals-simple`
+    );
+    if (!response.data.result) return Promise.reject(response);
+    return response.data.result;
+  } catch (error) {
+    console.error('팀의 목표 간단 조회 실패', error);
+    throw error;
+  }
+};
+
+export const useGetSimpleGoalList = (teamId: number) => {
+  return useQuery({
+    queryKey: [queryKey.GOAL_LIST_SIMPLE, teamId],
+    queryFn: () => getSimpleGoalList(teamId),
+  });
+};

--- a/src/apis/goal/useGetSimpleGoalList.ts.ts
+++ b/src/apis/goal/useGetSimpleGoalList.ts.ts
@@ -23,5 +23,6 @@ export const useGetSimpleGoalList = (teamId: number) => {
   return useQuery({
     queryKey: [queryKey.GOAL_LIST_SIMPLE, teamId],
     queryFn: () => getSimpleGoalList(teamId),
+    select: (data) => data.info,
   });
 };

--- a/src/apis/goal/useGetTeamMemberList.ts
+++ b/src/apis/goal/useGetTeamMemberList.ts
@@ -23,5 +23,6 @@ export const useGetTeamMemberList = (teamId: number) => {
   return useQuery({
     queryKey: [queryKey.TEAM_MEMBER_LIST, teamId],
     queryFn: () => getTeamMemberList(teamId),
+    select: (data) => data.info,
   });
 };

--- a/src/apis/goal/useGetTeamMemberList.ts
+++ b/src/apis/goal/useGetTeamMemberList.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '../axios';
+import type { CommonResponse } from '../../types/common';
+import type { TeamMemberListDto } from '../../types/goal';
+import { useQuery } from '@tanstack/react-query';
+import { queryKey } from '../../constants/queryKey';
+
+// 팀의 멤버 조회
+// 목표 생성시 담당자 할당에 사용
+const getTeamMemberList = async (teamId: number): Promise<TeamMemberListDto> => {
+  try {
+    const response = await axiosInstance.get<CommonResponse<TeamMemberListDto>>(
+      `/api/teams/${teamId}/teammate`
+    );
+    if (!response.data.result) return Promise.reject(response);
+    return response.data.result;
+  } catch (error) {
+    console.error('팀의 멤버 조회 실패', error);
+    throw error;
+  }
+};
+
+export const useGetTeamMemberList = (teamId: number) => {
+  return useQuery({
+    queryKey: [queryKey.TEAM_MEMBER_LIST, teamId],
+    queryFn: () => getTeamMemberList(teamId),
+  });
+};

--- a/src/apis/issue/useGetSimpleIssueList.ts
+++ b/src/apis/issue/useGetSimpleIssueList.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '../axios';
+import type { CommonResponse } from '../../types/common';
+import type { SimpleIssueListDto } from '../../types/issue';
+import { useQuery } from '@tanstack/react-query';
+import { queryKey } from '../../constants/queryKey';
+
+// 팀의 이슈들을 간단 조회
+// 이슈 연결시 사용
+const getSimpleIssueList = async (teamId: number): Promise<SimpleIssueListDto> => {
+  try {
+    const response = await axiosInstance.get<CommonResponse<SimpleIssueListDto>>(
+      `/api/teams/${teamId}/issues-simple`
+    );
+    if (!response.data.result) return Promise.reject(response);
+    return response.data.result;
+  } catch (error) {
+    console.error('팀의 이슈 간단 조회 실패', error);
+    throw error;
+  }
+};
+
+export const useGetSimpleIssueList = (teamId: number) => {
+  return useQuery({
+    queryKey: [queryKey.ISSUE_LIST_SIMPLE, teamId],
+    queryFn: () => getSimpleIssueList(teamId),
+  });
+};

--- a/src/apis/issue/useGetSimpleIssueList.ts
+++ b/src/apis/issue/useGetSimpleIssueList.ts
@@ -23,5 +23,6 @@ export const useGetSimpleIssueList = (teamId: number) => {
   return useQuery({
     queryKey: [queryKey.ISSUE_LIST_SIMPLE, teamId],
     queryFn: () => getSimpleIssueList(teamId),
+    select: (data) => data.info,
   });
 };

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -5,6 +5,7 @@ export const queryKey = {
   MY_PROFILE: 'my_profile',
   GITHUB_LINK: 'github_link',
   GOAL_LIST: 'goal_list',
+  GOAL_LIST_SIMPLE: 'goal_list_simple',
   ISSUE_LIST: 'issue_list',
   EXTERNAL_LIST: 'external_list',
   NOTI_LIST: 'noti_list',

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -7,6 +7,7 @@ export const queryKey = {
   GOAL_LIST: 'goal_list',
   GOAL_LIST_SIMPLE: 'goal_list_simple',
   ISSUE_LIST: 'issue_list',
+  ISSUE_LIST_SIMPLE: 'issue_list_simple',
   EXTERNAL_LIST: 'external_list',
   NOTI_LIST: 'noti_list',
   GOAL: 'goal',

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -11,4 +11,5 @@ export const queryKey = {
   NOTI_LIST: 'noti_list',
   GOAL: 'goal',
   EXTERNAL: 'external',
+  TEAM_MEMBER_LIST: 'team_member_list',
 };

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -46,3 +46,13 @@ export type SimpleGoalListDto = {
   cnt: number;
   info: SimpleGoal[];
 };
+
+export type TeamMember = {
+  id: number;
+  nickname: string;
+};
+
+export type TeamMemberListDto = {
+  cnt: number;
+  info: TeamMember[];
+};

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -39,3 +39,10 @@ export type RequestGoalListDto = {
 };
 
 export type ResponseGoalDto = CursorBasedResponse<GoalFilter[]>;
+
+export type SimpleGoal = Pick<Goal, 'id' | 'title'>;
+
+export type SimpleGoalListDto = {
+  cnt: number;
+  info: SimpleGoal[];
+};

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -47,3 +47,10 @@ export type RequestIssueListDto = {
 };
 
 export type ResponseIssueDto = CursorBasedResponse<IssueFilter[]>;
+
+export type SimpleIssue = Pick<Issue, 'id' | 'title'>;
+
+export type SimpleIssueListDto = {
+  cnt: number;
+  info: SimpleIssue[];
+};


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #130

---

### ✅ Key Changes

- 팀 내 이슈 간단 조회 API 세팅
  - 경로 `src\apis\issue\useGetSimpleIssueList.ts`
- 팀 내 목표 간단 조회 API 세팅
  - 경로 `src\apis\goal\useGetSimpleGoalList.ts.ts`
- 팀원 조회 (담당자) API 세팅
  - 경로 `src\apis\goal\useGetTeamMemberList.ts`

---

### 💬 To Reviewers
- 훅 내부에서 react-query의 select 옵션을 사용해 응답 데이터 중 info 배열만 추출하여 반환하도록 했습니다.
현재 예상되는 사용처가 단순 리스트 렌더링이라 cnt 등의 메타데이터는 사용하지 않을 것으로 보여서요!
추후 cnt가 필요해지는 경우 select 제거 또는 다른 훅 분리 고려 가능합니다.

@HiJuwon 해당 API들이 상세 페이지에서 사용되는 것으로 알고 있습니다. 제대로 작성되었는지 확인 한번만 부탁드립니다!