### PR TITLE
[FEAT] 사이드바 API 연동

### DIFF
--- a/src/components/Sidebar/FullSettingSidebarContent.tsx
+++ b/src/components/Sidebar/FullSettingSidebarContent.tsx
@@ -10,12 +10,17 @@ import usersIcon from '../../assets/icons/users.svg';
 import usersHoverIcon from '../../assets/icons/users-hover.svg';
 import userProfileIcon from '../../assets/icons/user-profile.svg';
 import userProfileHoverIcon from '../../assets/icons/user-profile-hover.svg';
+import type { WorkspaceResponse } from '../../types/setting';
 
 interface FullSettingSidebarContentProps {
   setExpanded: (value: boolean) => void;
+  workspaceProfile: WorkspaceResponse;
 }
 
-const FullSettingSidebarContent = ({ setExpanded }: FullSettingSidebarContentProps) => {
+const FullSettingSidebarContent = ({
+  setExpanded,
+  workspaceProfile,
+}: FullSettingSidebarContentProps) => {
   const navigate = useNavigate();
 
   return (
@@ -26,7 +31,7 @@ const FullSettingSidebarContent = ({ setExpanded }: FullSettingSidebarContentPro
             type="button"
             className="flex items-center gap-[0.8rem] cursor-pointer"
             onClick={() => {
-              navigate('/workspace');
+              navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/issue`);
             }}
           >
             <img src={leftArrowIcon} className="w-[3.2rem] h-[3.2rem]" alt="Workspace" />
@@ -45,7 +50,7 @@ const FullSettingSidebarContent = ({ setExpanded }: FullSettingSidebarContentPro
           <DropdownMenu headerTitle="워크스페이스" initialOpen={true}>
             <div className="flex flex-col justify-center items-flex-start gap-[1.6rem] pb-[1.6rem]">
               <SidebarItem
-                defaultIcon={vecocirclenavy}
+                defaultIcon={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
                 label="워크스페이스 프로필"
                 onClick={() => {
                   navigate('/workspace/setting');

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -204,7 +204,7 @@ const FullSidebarContent = ({
                 )}
                 onSorted={(newList: Team[]) => {
                   const teamIdList = newList.map((item: Team) => item.teamId);
-                  console.log(teamIdList);
+                  teamIdList.unshift(workspaceProfile.defaultTeamId);
                   patchWorkspaceTeams({ teamIdList });
                 }}
               />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -46,9 +46,13 @@ const FullSidebarContent = ({
               navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/issue`)
             }
           >
-            <img src={vecocirclenavy} className="w-[3.2rem] h-[3.2rem]" alt="Workspace" />
+            <img
+              src={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
+              className="w-[3.2rem] h-[3.2rem]"
+              alt="Workspace"
+            />
             <span className="font-body-b text-gray-600 letter-spacing-[-0.032rem]">
-              {workspaceProfile.workspaceName}
+              {workspaceProfile?.workspaceName}
             </span>
           </button>
           <div className="flex items-center gap-[1.6rem]">
@@ -94,7 +98,7 @@ const FullSidebarContent = ({
           <DropdownMenu headerTitle="워크스페이스 전체 팀" initialOpen={true}>
             <div className="flex flex-col">
               <DropdownMenu
-                headerTitle={workspaceProfile.workspaceName || ''}
+                headerTitle={workspaceProfile?.workspaceName || ''}
                 initialOpen={true}
                 headerTeamIcon={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
                 isNested={true}
@@ -152,9 +156,9 @@ const FullSidebarContent = ({
                 items={teams}
                 renderContent={(team, { listeners, attributes }, isOverlay) => (
                   <DropdownMenu
-                    headerTitle={team.teamName}
+                    headerTitle={team?.teamName}
                     initialOpen={!isOverlay}
-                    headerTeamIcon={team.teamImageUrl || vecocirclewhite}
+                    headerTeamIcon={team?.teamImageUrl || vecocirclewhite}
                     isNested={true}
                     dragHandle={
                       <button {...attributes} {...listeners} type="button" className="cursor-grab">

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -94,8 +94,8 @@ const FullSidebarContent = ({
         </button>
 
         <div className="flex flex-col items-start self-stretch">
-          {/* 첫 번째 드롭다운: 워크스페이스 전체 팀 */}
-          <DropdownMenu headerTitle="워크스페이스 전체 팀" initialOpen={true}>
+          {/* 첫 번째 드롭다운: 워크스페이스 기본 팀 */}
+          <DropdownMenu headerTitle="워크스페이스 기본 팀" initialOpen={true}>
             <div className="flex flex-col">
               <DropdownMenu
                 headerTitle={workspaceProfile?.workspaceName || ''}

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -15,18 +15,25 @@ import { useNavigate } from 'react-router-dom';
 import hamburgerIcon from '../../assets/icons/hamburger.svg';
 import SortableDropdownList from './SortableDropdownList';
 import vecocirclewhite from '../../assets/logos/veco-circle-logo-bg-white.svg';
-// import { usePatchWorkspaceTeams } from '../../apis/setting/usePatchWorkspaceTeams';
+import { usePatchWorkspaceTeams } from '../../apis/setting/usePatchWorkspaceTeams';
 import type { Team } from '../../types/setting';
+import type { WorkspaceResponse } from '../../types/setting';
 
 interface FullSidebarContentProps {
   setExpanded: (value: boolean) => void;
   teams: Team[];
+  isLoading: boolean;
+  workspaceProfile: WorkspaceResponse;
 }
 
-const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => {
+const FullSidebarContent = ({
+  setExpanded,
+  teams,
+  isLoading,
+  workspaceProfile,
+}: FullSidebarContentProps) => {
   const navigate = useNavigate();
-  // todo: 팀 순서 변경 API 연동
-  // const { mutate: patchWorkspaceTeams } = usePatchWorkspaceTeams();
+  const { mutate: patchWorkspaceTeams } = usePatchWorkspaceTeams();
 
   return (
     <div className="w-full p-[3.2rem] pe-[2rem] min-h-screen">
@@ -36,11 +43,13 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
             type="button"
             className="flex items-center gap-[0.8rem] cursor-pointer"
             onClick={() =>
-              navigate('/workspace/default/team/:teamId/issue'.replace(':teamId', String(1)))
+              navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/issue`)
             }
           >
             <img src={vecocirclenavy} className="w-[3.2rem] h-[3.2rem]" alt="Workspace" />
-            <span className="font-body-b text-gray-600 letter-spacing-[-0.032rem]">Workspace</span>
+            <span className="font-body-b text-gray-600 letter-spacing-[-0.032rem]">
+              {workspaceProfile.workspaceName}
+            </span>
           </button>
           <div className="flex items-center gap-[1.6rem]">
             <button
@@ -85,9 +94,9 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
           <DropdownMenu headerTitle="워크스페이스 전체 팀" initialOpen={true}>
             <div className="flex flex-col">
               <DropdownMenu
-                headerTitle="Workspace"
+                headerTitle={workspaceProfile.workspaceName || ''}
                 initialOpen={true}
-                headerTeamIcon={vecocirclenavy}
+                headerTeamIcon={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
                 isNested={true}
               >
                 <div className="flex flex-col justify-center items-flex-start gap-[1.6rem] pl-[3rem] pb-[1.6rem]">
@@ -96,15 +105,11 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     hoverIcon={goalHoverIcon}
                     label="목표"
                     onClick={() => {
-                      navigate(
-                        `/workspace/default/team/:teamId/goal`.replace(':teamId', String(1))
-                      );
+                      navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/goal`);
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/:teamId/goal/:goalId`
-                          .replace(':teamId', String(1))
-                          .replace(':goalId', String(123))
+                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/goal/:goalId`
                       );
                     }}
                   />
@@ -113,15 +118,11 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     hoverIcon={issueHoverIcon}
                     label="이슈"
                     onClick={() => {
-                      navigate(
-                        `/workspace/default/team/:teamId/issue`.replace(':teamId', String(1))
-                      );
+                      navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/issue`);
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/:teamId/issue/:issueId`
-                          .replace(':teamId', String(1))
-                          .replace(':issueId', String(123))
+                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/issue/:issueId`
                       );
                     }}
                   />
@@ -130,7 +131,7 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     hoverIcon={externalHoverIcon}
                     label="외부"
                     onClick={() => {
-                      navigate(`/workspace/default/team/:teamId/ext`.replace(':teamId', String(1)));
+                      navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/ext`);
                     }}
                   />
                 </div>
@@ -142,76 +143,68 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
         <div className="flex flex-col items-start self-stretch">
           <DropdownMenu headerTitle="나의 팀" initialOpen={true}>
             {/* Team 드롭다운 (내부 드롭다운) */}
-            <SortableDropdownList
-              items={teams}
-              renderContent={(team, { listeners, attributes }, isOverlay) => (
-                <DropdownMenu
-                  headerTitle={team.teamName}
-                  initialOpen={!isOverlay}
-                  headerTeamIcon={team.teamImageUrl || vecocirclewhite}
-                  isNested={true}
-                  dragHandle={
-                    <button {...attributes} {...listeners} type="button" className="cursor-grab">
-                      <img src={hamburgerIcon} className="w-[2.4rem] h-[2.4rem]" alt="Drag" />
-                    </button>
-                  }
-                >
-                  {!isOverlay && (
-                    <div className="flex flex-col justify-center items-start gap-[1.6rem] pl-[3rem] pb-[1.6rem]">
-                      <SidebarItem
-                        defaultIcon={goalIcon}
-                        hoverIcon={goalHoverIcon}
-                        label="목표"
-                        onClick={() => {
-                          navigate(
-                            `/workspace/team/:teamId/goal`.replace(':teamId', String(team.teamId))
-                          );
-                        }}
-                        onAddClick={() => {
-                          navigate(
-                            `/workspace/team/:teamId/goal/:goalId`
-                              .replace(':teamId', String(team.teamId))
-                              .replace(':goalId', String(123))
-                          );
-                        }}
-                      />
-                      <SidebarItem
-                        defaultIcon={issueIcon}
-                        hoverIcon={issueHoverIcon}
-                        label="이슈"
-                        onClick={() => {
-                          navigate(
-                            `/workspace/team/:teamId/issue`.replace(':teamId', String(team.teamId))
-                          );
-                        }}
-                        onAddClick={() => {
-                          navigate(
-                            `/workspace/team/:teamId/issue/:issueId`
-                              .replace(':teamId', String(team.teamId))
-                              .replace(':issueId', String(123))
-                          );
-                        }}
-                      />
-                      <SidebarItem
-                        defaultIcon={externalIcon}
-                        hoverIcon={externalHoverIcon}
-                        label="외부"
-                        onClick={() => {
-                          navigate(
-                            `/workspace/team/:teamId/ext`.replace(':teamId', String(team.teamId))
-                          );
-                        }}
-                      />
-                    </div>
-                  )}
-                </DropdownMenu>
-              )}
-              onSorted={(newList: Team[]) => {
-                const teamIdList = newList.map((item: Team) => item.teamId);
-                console.log(teamIdList);
-                // patchWorkspaceTeams(teamIdList);
-              }}
-            />
+            {isLoading ? null : teams.length === 0 ? (
+              <div className="text-gray-400 font-xsmall-r px-[3rem] pb-[1.6rem]">
+                등록된 팀이 없습니다.
+              </div>
+            ) : (
+              <SortableDropdownList
+                items={teams}
+                renderContent={(team, { listeners, attributes }, isOverlay) => (
+                  <DropdownMenu
+                    headerTitle={team.teamName}
+                    initialOpen={!isOverlay}
+                    headerTeamIcon={team.teamImageUrl || vecocirclewhite}
+                    isNested={true}
+                    dragHandle={
+                      <button {...attributes} {...listeners} type="button" className="cursor-grab">
+                        <img src={hamburgerIcon} className="w-[2.4rem] h-[2.4rem]" alt="Drag" />
+                      </button>
+                    }
+                  >
+                    {!isOverlay && (
+                      <div className="flex flex-col justify-center items-start gap-[1.6rem] pl-[3rem] pb-[1.6rem]">
+                        <SidebarItem
+                          defaultIcon={goalIcon}
+                          hoverIcon={goalHoverIcon}
+                          label="목표"
+                          onClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/goal`);
+                          }}
+                          onAddClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/goal/:goalId`);
+                          }}
+                        />
+                        <SidebarItem
+                          defaultIcon={issueIcon}
+                          hoverIcon={issueHoverIcon}
+                          label="이슈"
+                          onClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/issue`);
+                          }}
+                          onAddClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/issue/:issueId`);
+                          }}
+                        />
+                        <SidebarItem
+                          defaultIcon={externalIcon}
+                          hoverIcon={externalHoverIcon}
+                          label="외부"
+                          onClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/ext`);
+                          }}
+                        />
+                      </div>
+                    )}
+                  </DropdownMenu>
+                )}
+                onSorted={(newList: Team[]) => {
+                  const teamIdList = newList.map((item: Team) => item.teamId);
+                  console.log(teamIdList);
+                  patchWorkspaceTeams({ teamIdList });
+                }}
+              />
+            )}
           </DropdownMenu>
         </div>
       </div>

--- a/src/components/Sidebar/MiniSettingSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSettingSidebarContent.tsx
@@ -10,12 +10,17 @@ import userProfileIcon from '../../assets/icons/user-profile.svg';
 import userProfileHoverIcon from '../../assets/icons/user-profile-hover.svg';
 import leftArrowIcon from '../../assets/icons/left-arrow.svg';
 import expandIcon from '../../assets/icons/expand.svg';
+import type { WorkspaceResponse } from '../../types/setting';
 
 interface MiniSettingSidebarContentProps {
   setExpanded: (value: boolean) => void;
+  workspaceProfile: WorkspaceResponse;
 }
 
-const MiniSettingSidebarContent = ({ setExpanded }: MiniSettingSidebarContentProps) => {
+const MiniSettingSidebarContent = ({
+  setExpanded,
+  workspaceProfile,
+}: MiniSettingSidebarContentProps) => {
   const navigate = useNavigate();
 
   return (
@@ -26,7 +31,7 @@ const MiniSettingSidebarContent = ({ setExpanded }: MiniSettingSidebarContentPro
             type="button"
             className="flex w-[3.2rem] h-[3.2rem] shrink-0 items-center cursor-pointer"
             onClick={() => {
-              navigate('/workspace/team/default/issue');
+              navigate(`/workspace/team/${workspaceProfile.defaultTeamId}/issue`);
             }}
           >
             <img src={leftArrowIcon} className="w-full h-full shrink-0" alt="Workspace" />
@@ -44,7 +49,7 @@ const MiniSettingSidebarContent = ({ setExpanded }: MiniSettingSidebarContentPro
           <DropdownMenu headerTitle="워크" initialOpen={true}>
             <div className="flex flex-col justify-center items-flex-start gap-[1.6rem] pb-[1.6rem]">
               <SidebarItem
-                defaultIcon={vecocirclenavy}
+                defaultIcon={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
                 label=""
                 onClick={() => {
                   navigate('/workspace/setting');

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -15,12 +15,17 @@ import SortableDropdownList from './SortableDropdownList';
 import type { Team } from '../../types/setting';
 import type { WorkspaceResponse } from '../../types/setting';
 import vecocirclewhite from '../../assets/logos/veco-circle-logo-bg-white.svg';
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 
 interface MiniSidebarContentProps {
   setExpanded: (value: boolean) => void;
   teams: Team[];
   isLoading: boolean;
   workspaceProfile: WorkspaceResponse;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
 }
 
 const MiniSidebarContent = ({
@@ -28,8 +33,19 @@ const MiniSidebarContent = ({
   teams,
   isLoading,
   workspaceProfile,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
 }: MiniSidebarContentProps) => {
   const navigate = useNavigate();
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage]);
+
   return (
     <div className="w-full p-[3.2rem] pe-[2rem] min-h-screen">
       <div className="flex flex-col items-start gap-[3.2rem] self-stretch">
@@ -132,53 +148,56 @@ const MiniSidebarContent = ({
                 등록된 팀이 없습니다.
               </div>
             ) : (
-              <SortableDropdownList
-                items={teams}
-                renderContent={(team, {}, isOverlay) => (
-                  <DropdownMenu
-                    headerTitle=""
-                    initialOpen={!isOverlay}
-                    headerTeamIcon={team.teamImageUrl || vecocirclewhite}
-                    isNested={true}
-                  >
-                    {!isOverlay && (
-                      <div className="flex flex-col justify-center items-start gap-[1.6rem] pb-[1.6rem]">
-                        <SidebarItem
-                          defaultIcon={goalIcon}
-                          hoverIcon={goalHoverIcon}
-                          label=""
-                          onClick={() => {
-                            navigate(`/workspace/team/${team.teamId}/goal`);
-                          }}
-                          onAddClick={() => {
-                            navigate(`/workspace/team/${team.teamId}/goal/:goalId`);
-                          }}
-                        />
-                        <SidebarItem
-                          defaultIcon={issueIcon}
-                          hoverIcon={issueHoverIcon}
-                          label=""
-                          onClick={() => {
-                            navigate(`/workspace/team/${team.teamId}/issue`);
-                          }}
-                          onAddClick={() => {
-                            navigate(`/workspace/team/${team.teamId}/issue/:issueId`);
-                          }}
-                        />
-                        <SidebarItem
-                          defaultIcon={externalIcon}
-                          hoverIcon={externalHoverIcon}
-                          label=""
-                          onClick={() => {
-                            navigate(`/workspace/team/${team.teamId}/ext`);
-                          }}
-                        />
-                      </div>
-                    )}
-                  </DropdownMenu>
-                )}
-                onSorted={(newList: any) => console.log(newList)}
-              />
+              <>
+                <SortableDropdownList
+                  items={teams}
+                  renderContent={(team, {}, isOverlay) => (
+                    <DropdownMenu
+                      headerTitle=""
+                      initialOpen={!isOverlay}
+                      headerTeamIcon={team.teamImageUrl || vecocirclewhite}
+                      isNested={true}
+                    >
+                      {!isOverlay && (
+                        <div className="flex flex-col justify-center items-start gap-[1.6rem] pb-[1.6rem]">
+                          <SidebarItem
+                            defaultIcon={goalIcon}
+                            hoverIcon={goalHoverIcon}
+                            label=""
+                            onClick={() => {
+                              navigate(`/workspace/team/${team.teamId}/goal`);
+                            }}
+                            onAddClick={() => {
+                              navigate(`/workspace/team/${team.teamId}/goal/:goalId`);
+                            }}
+                          />
+                          <SidebarItem
+                            defaultIcon={issueIcon}
+                            hoverIcon={issueHoverIcon}
+                            label=""
+                            onClick={() => {
+                              navigate(`/workspace/team/${team.teamId}/issue`);
+                            }}
+                            onAddClick={() => {
+                              navigate(`/workspace/team/${team.teamId}/issue/:issueId`);
+                            }}
+                          />
+                          <SidebarItem
+                            defaultIcon={externalIcon}
+                            hoverIcon={externalHoverIcon}
+                            label=""
+                            onClick={() => {
+                              navigate(`/workspace/team/${team.teamId}/ext`);
+                            }}
+                          />
+                        </div>
+                      )}
+                    </DropdownMenu>
+                  )}
+                  onSorted={(newList: any) => console.log(newList)}
+                />
+                <div ref={ref} className="h-[1rem]" />
+              </>
             )}
           </DropdownMenu>
         </div>

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -68,8 +68,8 @@ const MiniSidebarContent = ({ setExpanded, teams, workspaceProfile }: MiniSideba
         </button>
 
         <div className="flex flex-col items-start self-stretch">
-          {/* 첫 번째 드롭다운: 워크스페이스 전체 팀 */}
-          <DropdownMenu headerTitle="전체" initialOpen={true}>
+          {/* 첫 번째 드롭다운: 워크스페이스 기본 팀 */}
+          <DropdownMenu headerTitle="기본" initialOpen={true}>
             <div className="flex flex-col">
               <DropdownMenu
                 headerTitle=""

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -13,13 +13,16 @@ import DropdownMenu from './DropdownMenu';
 import SidebarItem from './SidebarItem';
 import SortableDropdownList from './SortableDropdownList';
 import type { Team } from '../../types/setting';
+import type { WorkspaceResponse } from '../../types/setting';
+import vecocirclewhite from '../../assets/logos/veco-circle-logo-bg-white.svg';
 
 interface MiniSidebarContentProps {
   setExpanded: (value: boolean) => void;
   teams: Team[];
+  workspaceProfile: WorkspaceResponse;
 }
 
-const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => {
+const MiniSidebarContent = ({ setExpanded, teams, workspaceProfile }: MiniSidebarContentProps) => {
   const navigate = useNavigate();
   return (
     <div className="w-full p-[3.2rem] pe-[2rem] min-h-screen">
@@ -28,9 +31,15 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
           <button
             type="button"
             className="flex w-[3.2rem] h-[3.2rem] shrink-0 items-center cursor-pointer"
-            onClick={() => navigate('/workspace/team/default/issue')}
+            onClick={() =>
+              navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/issue`)
+            }
           >
-            <img src={vecocirclenavy} className="w-full h-full shrink-0" alt="Workspace" />
+            <img
+              src={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
+              className="w-full h-full shrink-0"
+              alt="Workspace"
+            />
           </button>
           <button
             type="button"
@@ -65,7 +74,7 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
               <DropdownMenu
                 headerTitle=""
                 initialOpen={true}
-                headerTeamIcon={vecocirclenavy}
+                headerTeamIcon={workspaceProfile?.workspaceImageUrl || vecocirclenavy}
                 isNested={true}
               >
                 <div className="flex flex-col justify-center items-flex-start gap-[1.6rem] pb-[1.6rem]">
@@ -74,10 +83,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                     hoverIcon={goalHoverIcon}
                     label=""
                     onClick={() => {
-                      navigate(`/workspace/team/default/goal`);
+                      navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/goal`);
                     }}
                     onAddClick={() => {
-                      navigate(`/workspace/team/default/goal/:goalId`);
+                      navigate(
+                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/goal/:goalId`
+                      );
                     }}
                   />
                   <SidebarItem
@@ -85,10 +96,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                     hoverIcon={issueHoverIcon}
                     label=""
                     onClick={() => {
-                      navigate(`/workspace/team/default/issue`);
+                      navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/issue`);
                     }}
                     onAddClick={() => {
-                      navigate(`/workspace/team/default/issue/:issueId`);
+                      navigate(
+                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/issue/:issueId`
+                      );
                     }}
                   />
                   <SidebarItem
@@ -96,7 +109,7 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                     hoverIcon={externalHoverIcon}
                     label=""
                     onClick={() => {
-                      navigate(`/workspace/team/default/ext`);
+                      navigate(`/workspace/default/team/${workspaceProfile.defaultTeamId}/ext`);
                     }}
                   />
                 </div>
@@ -114,7 +127,7 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                 <DropdownMenu
                   headerTitle=""
                   initialOpen={!isOverlay}
-                  headerTeamIcon={team.teamImageUrl}
+                  headerTeamIcon={team.teamImageUrl || vecocirclewhite}
                   isNested={true}
                 >
                   {!isOverlay && (
@@ -124,10 +137,10 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                         hoverIcon={goalHoverIcon}
                         label=""
                         onClick={() => {
-                          navigate(`/workspace/team/:teamId/goal`);
+                          navigate(`/workspace/team/${team.teamId}/goal`);
                         }}
                         onAddClick={() => {
-                          navigate(`/workspace/team/:teamId/goal/:goalId`);
+                          navigate(`/workspace/team/${team.teamId}/goal/:goalId`);
                         }}
                       />
                       <SidebarItem
@@ -135,10 +148,10 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                         hoverIcon={issueHoverIcon}
                         label=""
                         onClick={() => {
-                          navigate(`/workspace/team/:teamId/issue`);
+                          navigate(`/workspace/team/${team.teamId}/issue`);
                         }}
                         onAddClick={() => {
-                          navigate(`/workspace/team/:teamId/issue/:issueId`);
+                          navigate(`/workspace/team/${team.teamId}/issue/:issueId`);
                         }}
                       />
                       <SidebarItem
@@ -146,7 +159,7 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                         hoverIcon={externalHoverIcon}
                         label=""
                         onClick={() => {
-                          navigate(`/workspace/team/:teamId/ext`);
+                          navigate(`/workspace/team/${team.teamId}/ext`);
                         }}
                       />
                     </div>

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -19,10 +19,16 @@ import vecocirclewhite from '../../assets/logos/veco-circle-logo-bg-white.svg';
 interface MiniSidebarContentProps {
   setExpanded: (value: boolean) => void;
   teams: Team[];
+  isLoading: boolean;
   workspaceProfile: WorkspaceResponse;
 }
 
-const MiniSidebarContent = ({ setExpanded, teams, workspaceProfile }: MiniSidebarContentProps) => {
+const MiniSidebarContent = ({
+  setExpanded,
+  teams,
+  isLoading,
+  workspaceProfile,
+}: MiniSidebarContentProps) => {
   const navigate = useNavigate();
   return (
     <div className="w-full p-[3.2rem] pe-[2rem] min-h-screen">
@@ -121,53 +127,59 @@ const MiniSidebarContent = ({ setExpanded, teams, workspaceProfile }: MiniSideba
         <div className="flex flex-col items-start self-stretch">
           <DropdownMenu headerTitle="나의" initialOpen={true}>
             {/* Team1 드롭다운 (내부 드롭다운) */}
-            <SortableDropdownList
-              items={teams}
-              renderContent={(team, {}, isOverlay) => (
-                <DropdownMenu
-                  headerTitle=""
-                  initialOpen={!isOverlay}
-                  headerTeamIcon={team.teamImageUrl || vecocirclewhite}
-                  isNested={true}
-                >
-                  {!isOverlay && (
-                    <div className="flex flex-col justify-center items-start gap-[1.6rem] pb-[1.6rem]">
-                      <SidebarItem
-                        defaultIcon={goalIcon}
-                        hoverIcon={goalHoverIcon}
-                        label=""
-                        onClick={() => {
-                          navigate(`/workspace/team/${team.teamId}/goal`);
-                        }}
-                        onAddClick={() => {
-                          navigate(`/workspace/team/${team.teamId}/goal/:goalId`);
-                        }}
-                      />
-                      <SidebarItem
-                        defaultIcon={issueIcon}
-                        hoverIcon={issueHoverIcon}
-                        label=""
-                        onClick={() => {
-                          navigate(`/workspace/team/${team.teamId}/issue`);
-                        }}
-                        onAddClick={() => {
-                          navigate(`/workspace/team/${team.teamId}/issue/:issueId`);
-                        }}
-                      />
-                      <SidebarItem
-                        defaultIcon={externalIcon}
-                        hoverIcon={externalHoverIcon}
-                        label=""
-                        onClick={() => {
-                          navigate(`/workspace/team/${team.teamId}/ext`);
-                        }}
-                      />
-                    </div>
-                  )}
-                </DropdownMenu>
-              )}
-              onSorted={(newList: any) => console.log(newList)}
-            />
+            {isLoading ? null : teams.length === 0 ? (
+              <div className="text-gray-400 font-xsmall-r px-[3rem] pb-[1.6rem]">
+                등록된 팀이 없습니다.
+              </div>
+            ) : (
+              <SortableDropdownList
+                items={teams}
+                renderContent={(team, {}, isOverlay) => (
+                  <DropdownMenu
+                    headerTitle=""
+                    initialOpen={!isOverlay}
+                    headerTeamIcon={team.teamImageUrl || vecocirclewhite}
+                    isNested={true}
+                  >
+                    {!isOverlay && (
+                      <div className="flex flex-col justify-center items-start gap-[1.6rem] pb-[1.6rem]">
+                        <SidebarItem
+                          defaultIcon={goalIcon}
+                          hoverIcon={goalHoverIcon}
+                          label=""
+                          onClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/goal`);
+                          }}
+                          onAddClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/goal/:goalId`);
+                          }}
+                        />
+                        <SidebarItem
+                          defaultIcon={issueIcon}
+                          hoverIcon={issueHoverIcon}
+                          label=""
+                          onClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/issue`);
+                          }}
+                          onAddClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/issue/:issueId`);
+                          }}
+                        />
+                        <SidebarItem
+                          defaultIcon={externalIcon}
+                          hoverIcon={externalHoverIcon}
+                          label=""
+                          onClick={() => {
+                            navigate(`/workspace/team/${team.teamId}/ext`);
+                          }}
+                        />
+                      </div>
+                    )}
+                  </DropdownMenu>
+                )}
+                onSorted={(newList: any) => console.log(newList)}
+              />
+            )}
           </DropdownMenu>
         </div>
       </div>

--- a/src/components/Sidebar/SettingSidebar.tsx
+++ b/src/components/Sidebar/SettingSidebar.tsx
@@ -2,9 +2,11 @@ import FullSettingSidebarContent from './FullSettingSidebarContent';
 import MiniSettingSidebarContent from './MiniSettingSidebarContent';
 import clsx from 'clsx';
 import { useSidebarStore } from '../../stores/useSidebarStore';
+import { useGetWorkspaceProfile } from '../../apis/setting/useGetWorkspaceProfile';
 
 const SettingSidebar = () => {
   const { isOpen, toggle } = useSidebarStore();
+  const { data: workspaceProfile } = useGetWorkspaceProfile();
 
   return (
     <div
@@ -24,7 +26,7 @@ const SettingSidebar = () => {
           )}
         >
           <div className="h-full overflow-y-auto sidebar-scroll">
-            <FullSettingSidebarContent setExpanded={toggle} />
+            <FullSettingSidebarContent setExpanded={toggle} workspaceProfile={workspaceProfile!} />
           </div>
         </div>
 
@@ -36,7 +38,7 @@ const SettingSidebar = () => {
           )}
         >
           <div className="h-full overflow-y-auto sidebar-scroll">
-            <MiniSettingSidebarContent setExpanded={toggle} />
+            <MiniSettingSidebarContent setExpanded={toggle} workspaceProfile={workspaceProfile!} />
           </div>
         </div>
       </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,31 +1,17 @@
 import MiniSidebarContent from './MiniSidebarContent';
 import FullSidebarContent from './FullSidebarContent';
-import vecocirclewhite from '../../assets/logos/veco-circle-logo-bg-white.svg';
 import clsx from 'clsx';
 import { useSidebarStore } from '../../stores/useSidebarStore';
-// import { useGetWorkspaceTeams } from '../../apis/setting/useGetWorkspaceTeams';
+import { useGetWorkspaceTeams } from '../../apis/setting/useGetWorkspaceTeams';
+import type { Team } from '../../types/setting';
+import { useGetWorkspaceProfile } from '../../apis/setting/useGetWorkspaceProfile';
 
 const Sidebar = () => {
   const { isOpen, toggle } = useSidebarStore();
-  // todo: 팀 목록 조회 API 연동
-  // const { data: teams = [] } = useGetWorkspaceTeams();
+  const { data: workspaceProfile } = useGetWorkspaceProfile();
+  const { data, isLoading } = useGetWorkspaceTeams();
 
-  const teams = [
-    {
-      teamId: 2,
-      teamName: 'Team1',
-      teamImageUrl: vecocirclewhite,
-      memberCount: 2,
-      createdAt: '2025-01-01',
-    },
-    {
-      teamId: 3,
-      teamName: 'Team2',
-      teamImageUrl: vecocirclewhite,
-      memberCount: 2,
-      createdAt: '2025-01-01',
-    },
-  ];
+  const teams: Team[] = data ? data.pages.flatMap((page) => page.teamList) : [];
 
   return (
     <div
@@ -45,7 +31,12 @@ const Sidebar = () => {
           )}
         >
           <div className="h-full overflow-y-auto sidebar-scroll">
-            <FullSidebarContent setExpanded={toggle} teams={teams} />
+            <FullSidebarContent
+              setExpanded={toggle}
+              teams={teams}
+              isLoading={isLoading}
+              workspaceProfile={workspaceProfile!}
+            />
           </div>
         </div>
 
@@ -57,7 +48,11 @@ const Sidebar = () => {
           )}
         >
           <div className="h-full overflow-y-auto sidebar-scroll">
-            <MiniSidebarContent setExpanded={toggle} teams={teams} />
+            <MiniSidebarContent
+              setExpanded={toggle}
+              teams={teams}
+              workspaceProfile={workspaceProfile!}
+            />
           </div>
         </div>
       </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -11,7 +11,7 @@ const Sidebar = () => {
   const { data: workspaceProfile } = useGetWorkspaceProfile();
   const { data, isLoading } = useGetWorkspaceTeams();
 
-  const teams: Team[] = data ? data.pages.flatMap((page) => page.teamList) : [];
+  const teams: Team[] = data ? data.pages.flatMap((page) => page.teamList).slice(1) : [];
 
   return (
     <div

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -9,7 +9,8 @@ import { useGetWorkspaceProfile } from '../../apis/setting/useGetWorkspaceProfil
 const Sidebar = () => {
   const { isOpen, toggle } = useSidebarStore();
   const { data: workspaceProfile } = useGetWorkspaceProfile();
-  const { data, isLoading } = useGetWorkspaceTeams();
+  const { data, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useGetWorkspaceTeams();
 
   const teams: Team[] = data ? data.pages.flatMap((page) => page.teamList).slice(1) : [];
 
@@ -36,6 +37,9 @@ const Sidebar = () => {
               teams={teams}
               isLoading={isLoading}
               workspaceProfile={workspaceProfile!}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              fetchNextPage={fetchNextPage}
             />
           </div>
         </div>
@@ -53,6 +57,9 @@ const Sidebar = () => {
               teams={teams}
               isLoading={isLoading}
               workspaceProfile={workspaceProfile!}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              fetchNextPage={fetchNextPage}
             />
           </div>
         </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -51,6 +51,7 @@ const Sidebar = () => {
             <MiniSidebarContent
               setExpanded={toggle}
               teams={teams}
+              isLoading={isLoading}
               workspaceProfile={workspaceProfile!}
             />
           </div>


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #137

---

### ✅ Key Changes

- 워크스페이스 기본 팀 조회
  - 목표, 이슈, 외부 기본 페이지 url 연결
- 워크스페이스 개별 팀 조회
  - 목표, 이슈, 외부 기본 페이지 url 연결
  - 등록된 팀이 없을 시 '등록된 팀이 없습니다.' 렌더링 처리
- 팀 목록 순서 변경 API 연동

---

### 📸 스크린샷 or 실행영상
https://github.com/user-attachments/assets/e5c67cd7-66ac-453b-98d0-9602935c4e10
- 목표, 이슈, 외부 버튼 클릭시 url이 변경됩니다.
<img width="378" height="641" alt="image" src="https://github.com/user-attachments/assets/0733cffe-a5af-44d1-8eff-ca2f55cb2225" />

- 개별 팀이 없을시 보이는 화면

---

### 💬 To Reviewers
- 이슈, 목표 생성 API 만들어지면 사이드바 '+' 버튼에 연동하겠습니다.
- 개별 팀의 **이슈**를 클릭하면 "**목표**를 생성하세요"라고 잘못된 메시지가 뜨고 있습니다.
- 개별 팀의 외부를 클릭하면 콘솔에 `Error fetching external list` 에러가 뜹니다.
사이드바 API 연동 후 해당사항 수정 해주시면 될 것 같습니다.
