### PR TITLE
[MOD] 상세페이지 url 구조 변경

### DIFF
--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -169,9 +169,11 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                         }}
                         onAddClick={() => {
                           navigate(
-                            `/workspace/team/:teamId/goal/:goalId`
-                              .replace(':teamId', String(team.teamId))
-                              .replace(':goalId', String(123))
+                            // 바꾼 부분 여기임
+                            `/workspace/team/:teamId/goal/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
                           );
                         }}
                       />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -102,9 +102,10 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/:teamId/goal/:goalId`
-                          .replace(':teamId', String(1))
-                          .replace(':goalId', String(123))
+                        `/workspace/default/team/:teamId/goal/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
                       );
                     }}
                   />
@@ -119,9 +120,10 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/:teamId/issue/:issueId`
-                          .replace(':teamId', String(1))
-                          .replace(':issueId', String(123))
+                        `/workspace/default/team/:teamId/issue/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
                       );
                     }}
                   />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -187,9 +187,10 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                         }}
                         onAddClick={() => {
                           navigate(
-                            `/workspace/team/:teamId/issue/:issueId`
-                              .replace(':teamId', String(team.teamId))
-                              .replace(':issueId', String(123))
+                            `/workspace/team/:teamId/issue/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
                           );
                         }}
                       />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -169,7 +169,6 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                         }}
                         onAddClick={() => {
                           navigate(
-                            // 바꾼 부분 여기임
                             `/workspace/team/:teamId/goal/detail/create`.replace(
                               ':teamId',
                               String(team.teamId)

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -77,7 +77,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                       navigate(`/workspace/team/default/goal`);
                     }}
                     onAddClick={() => {
-                      navigate(`/workspace/team/default/goal/:goalId`);
+                      navigate(
+                        `/workspace/default/team/:teamId/goal/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
+                      );
                     }}
                   />
                   <SidebarItem
@@ -88,7 +93,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                       navigate(`/workspace/team/default/issue`);
                     }}
                     onAddClick={() => {
-                      navigate(`/workspace/team/default/issue/:issueId`);
+                      navigate(
+                        `/workspace/default/team/:teamId/issue/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
+                      );
                     }}
                   />
                   <SidebarItem
@@ -127,7 +137,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                           navigate(`/workspace/team/:teamId/goal`);
                         }}
                         onAddClick={() => {
-                          navigate(`/workspace/team/:teamId/goal/:goalId`);
+                          navigate(
+                            `/workspace/team/:teamId/goal/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
+                          );
                         }}
                       />
                       <SidebarItem
@@ -138,7 +153,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                           navigate(`/workspace/team/:teamId/issue`);
                         }}
                         onAddClick={() => {
-                          navigate(`/workspace/team/:teamId/issue/:issueId`);
+                          navigate(
+                            `/workspace/team/:teamId/issue/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
+                          );
                         }}
                       />
                       <SidebarItem

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -109,7 +109,7 @@ const MiniSidebarContent = ({
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/goal/detai/create`
+                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/goal/detail/create`
                       );
                     }}
                   />

--- a/src/hooks/useToggleMode.ts
+++ b/src/hooks/useToggleMode.ts
@@ -1,0 +1,48 @@
+/**
+ * 목표/이슈/외부 상세페이지에서 mode 전환을 위한 커스텀 훅
+ * - 생성 모드(create), 수정 모드(edit), 조회 모드(view) 간의 전환을 관리
+ * - 모드별 URL 경로를 변경하여 페이지 전환을 처리
+ */
+
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCallback } from 'react';
+
+type Mode = 'create' | 'view' | 'edit';
+
+interface UseToggleModeProps {
+  mode: Mode;
+  setMode: (mode: Mode) => void;
+  type: 'goal' | 'issue' | 'ext';
+  id: string;
+  isDefaultTeam: boolean;
+}
+
+export const useToggleMode = ({ mode, setMode, type, id, isDefaultTeam }: UseToggleModeProps) => {
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>();
+
+  const getBasePath = () => {
+    if (!teamId) return '';
+    return isDefaultTeam
+      ? `/workspace/default/team/${teamId}/${type}`
+      : `/workspace/team/${teamId}/${type}`;
+  };
+
+  const handleToggleMode = useCallback(() => {
+    const base = getBasePath();
+    if (!base) return;
+
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`${base}/${id}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`${base}/${id}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`${base}/${id}/edit`);
+    }
+  }, [mode, id, navigate, setMode, isDefaultTeam, teamId, type]);
+
+  return handleToggleMode;
+};

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -53,13 +53,13 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   const handleToggleMode = () => {
     if (mode === 'create') {
       setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeExtId}`);
+      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
     } else if (mode === 'edit') {
       setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeExtId}`);
+      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
     } else if (mode === 'view') {
       setMode('edit');
-      navigate(`/workspace/team/${teamId}/issue/${fakeExtId}/edit`);
+      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}/edit`);
     }
   };
 

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -27,9 +27,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface ExternalDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -24,7 +24,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -39,9 +39,6 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeExtId = '123'; // 임시 extId (TODO: 실제로는 외부이슈 작성 API로부터 받아온 result의 extId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -50,18 +47,13 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'ext',
+    id: fakeExtId,
+    isDefaultTeam: false,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -24,6 +24,8 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useGetGoalName } from '../../apis/goal/useGetGoalName';
 
 /**
  * 구현 완료하면 이 주석은 지운다.
@@ -37,20 +39,37 @@ import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 // (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
 // (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
 interface GoalDetailProps {
-  mode: 'create' | 'view' | 'edit';
+  initialMode: 'create' | 'view' | 'edit';
 }
 
-const GoalDetail = ({ mode }: GoalDetailProps) => {
+const GoalDetail = ({ initialMode }: GoalDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
+
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string; goalId: string }>(); // URL 파라미터에서 teamId와 goalId 가져오기
+  const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown, closeDropdown } = useDropdownActions();
 
-  // 상태에 따라 작성 완료 버튼의 상태 결정
-  const [isCompleted, setIsCompleted] = useState(mode === 'view');
-  const isEditable = mode === 'create' || mode === 'edit';
-  const isTitleFilled = title.trim().length > 0;
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -78,10 +97,6 @@ const GoalDetail = ({ mode }: GoalDetailProps) => {
     전시현: IcProfile,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -96,11 +111,11 @@ const GoalDetail = ({ mode }: GoalDetailProps) => {
             defaultTitle="목표를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -199,11 +214,11 @@ const GoalDetail = ({ mode }: GoalDetailProps) => {
             </div>
           </div>
 
-          {/* 작성 완료 버튼 */}
+          {/* 작성 완료 버튼 : 상세페이지 mode 전환을 관리 */}
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -25,16 +25,32 @@ import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 
-const GoalDetail = () => {
+/**
+ * 구현 완료하면 이 주석은 지운다.
+ * - 생성 모드: 댓글창 안 보임 + 제목&상세설명 작성 가능 + 작성 완료 버튼으로 떠있음(초기 비활성화->제목 입력 후 활성화됨)
+ * - 조회 모드: 댓글창 보임 + 제목&상세설명 수정 불가 + 수정하기 버튼으로 떠있음(활성화)
+ * - 수정 모드: 댓글창 안 보임 + 제목&상세설명 수정 가능 + 작성 완료 버튼으로 떠있음(활성화)
+ */
+
+// 상세페이지 모드 구분
+// (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+// (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+// (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+interface GoalDetailProps {
+  mode: 'create' | 'view' | 'edit';
+}
+
+const GoalDetail = ({ mode }: GoalDetailProps) => {
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
-
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
-
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown, closeDropdown } = useDropdownActions();
+
+  // 상태에 따라 작성 완료 버튼의 상태 결정
+  const [isCompleted, setIsCompleted] = useState(mode === 'view');
+  const isEditable = mode === 'create' || mode === 'edit';
+  const isTitleFilled = title.trim().length > 0;
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -61,9 +77,6 @@ const GoalDetail = () => {
     전채운: IcProfile,
     전시현: IcProfile,
   };
-
-  // const dateIconMap = IcDate; // '기한' 속성 아이콘 매핑
-  // const issueIconMap = IcIssue; // '이슈' 속성 아이콘 매핑
 
   const handleToggle = () => {
     setIsCompleted((prev) => !prev);

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -26,10 +26,11 @@ import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useNavigate, useParams } from 'react-router-dom';
 
-// 상세페이지 모드 구분
-// (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
-// (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
-// (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
 interface GoalDetailProps {
   initialMode: 'create' | 'view' | 'edit';
 }
@@ -41,7 +42,7 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   const [option, setOption] = useState<string>('이슈');
 
   const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string; goalId: string }>(); // URL 파라미터에서 teamId와 goalId 가져오기
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -24,7 +24,7 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -40,9 +40,6 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -51,18 +48,13 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'goal',
+    id: fakeGoalId,
+    isDefaultTeam: false,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -25,14 +25,6 @@ import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useGetGoalName } from '../../apis/goal/useGetGoalName';
-
-/**
- * 구현 완료하면 이 주석은 지운다.
- * - 생성 모드: 댓글창 안 보임 + 제목&상세설명 작성 가능 + 작성 완료 버튼으로 떠있음(초기 비활성화->제목 입력 후 활성화됨)
- * - 조회 모드: 댓글창 보임 + 제목&상세설명 수정 불가 + 수정하기 버튼으로 떠있음(활성화)
- * - 수정 모드: 댓글창 안 보임 + 제목&상세설명 수정 가능 + 작성 완료 버튼으로 떠있음(활성화)
- */
 
 // 상세페이지 모드 구분
 // (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -27,9 +27,9 @@ import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface GoalDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -23,16 +23,44 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const IssueDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface IssueDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const IssueDetail = ({ initialMode }: IssueDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
 
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeIssueId = '123'; // 임시 issueId (TODO: 실제로는 이슈 작성 API로부터 받아온 result의 issueId 값을 사용 예정)
 
-  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
-  const { openDropdown } = useDropdownActions();
+  const { isOpen, content } = useDropdownInfo(); // 작성 완료 여부 (view 모드일 때 true)
+  const { openDropdown } = useDropdownActions(); // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -67,10 +95,6 @@ const IssueDetail = () => {
     '기획 및 요구사항 분석': IcGoal,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -85,11 +109,11 @@ const IssueDetail = () => {
             defaultTitle="이슈를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -173,7 +197,7 @@ const IssueDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -23,7 +23,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -38,9 +38,6 @@ const IssueDetail = ({ initialMode }: IssueDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeIssueId = '123'; // 임시 issueId (TODO: 실제로는 이슈 작성 API로부터 받아온 result의 issueId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 작성 완료 여부 (view 모드일 때 true)
@@ -49,18 +46,13 @@ const IssueDetail = ({ initialMode }: IssueDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'issue',
+    id: fakeIssueId,
+    isDefaultTeam: false,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -26,9 +26,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface IssueDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -27,9 +27,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface WorkspaceExternalDetailProps {
   initialMode: 'create' | 'view' | 'edit';
@@ -39,7 +39,7 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+  const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 외부이슈 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -1,5 +1,5 @@
 // WorkspaceExternalDetail.tsx
-// 워크스페이스 전체 팀 외부 상세페이지
+// 워크스페이스 전체 팀 - 외부 상세페이지
 
 import { useState } from 'react';
 import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
@@ -24,16 +24,44 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const WorkspaceExternalDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface WorkspaceExternalDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
 
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -75,10 +103,6 @@ const WorkspaceExternalDetail = () => {
     Github: IcExt,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -93,11 +117,11 @@ const WorkspaceExternalDetail = () => {
             defaultTitle="제목을 작성해보세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -190,7 +214,7 @@ const WorkspaceExternalDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -24,7 +24,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -39,9 +39,6 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -50,18 +47,13 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'ext',
+    id: fakeExtId,
+    isDefaultTeam: true,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -27,9 +27,9 @@ import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface WorkspaceGoalDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -1,5 +1,5 @@
 // WorkspaceGoalDetail.tsx
-// 워크스페이스 전체 팀 목표 상세페이지
+// 워크스페이스 전체 팀 - 목표 상세페이지
 
 import { useState } from 'react';
 import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
@@ -24,17 +24,45 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const WorkspaceGoalDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface WorkspaceGoalDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
-
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
-
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
+
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown, closeDropdown } = useDropdownActions();
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -62,13 +90,6 @@ const WorkspaceGoalDetail = () => {
     전시현: IcProfile,
   };
 
-  // const dateIconMap = IcDate; // '기한' 속성 아이콘 매핑
-  // const issueIconMap = IcIssue; // '이슈' 속성 아이콘 매핑
-
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -83,11 +104,11 @@ const WorkspaceGoalDetail = () => {
             defaultTitle="목표를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -190,7 +211,7 @@ const WorkspaceGoalDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -24,7 +24,7 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -40,9 +40,6 @@ const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -51,18 +48,13 @@ const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'goal',
+    id: fakeGoalId,
+    isDefaultTeam: true,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -23,7 +23,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -38,9 +38,6 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -49,18 +46,13 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'issue',
+    id: fakeIssueId,
+    isDefaultTeam: true,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -23,16 +23,44 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const WorkspaceIssueDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface WorkspaceIssueDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
 
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -67,10 +95,6 @@ const WorkspaceIssueDetail = () => {
     '기획 및 요구사항 분석': IcGoal,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -85,11 +109,11 @@ const WorkspaceIssueDetail = () => {
             defaultTitle="이슈를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -173,7 +197,7 @@ const WorkspaceIssueDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -26,9 +26,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface WorkspaceIssueDetailProps {
   initialMode: 'create' | 'view' | 'edit';
@@ -38,7 +38,7 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+  const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 이슈 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -84,7 +84,9 @@ export const protectedRoutes: RouteObject[] = [
 
           // 외부 연동 관련 라우트
           { path: 'ext', element: <ExternalHome /> },
-          { path: 'ext/:extId', element: <ExternalDetail /> },
+          { path: 'ext/detail/create', element: <ExternalDetail initialMode="create" /> },
+          { path: 'ext/:extId', element: <ExternalDetail initialMode="view" /> },
+          { path: 'ext/:extId/edit', element: <ExternalDetail initialMode="edit" /> },
         ],
       },
     ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -54,12 +54,24 @@ export const protectedRoutes: RouteObject[] = [
         children: [
           // 기본 경로는 이슈 페이지로 리다이렉트
           { index: true, element: <Navigate to="issue" replace /> },
+
+          // 워크스페이스 이슈 관련 라우트
           { path: 'issue', element: <WorkspaceIssue /> },
-          { path: 'issue/:issueId', element: <WorkspaceIssueDetail /> },
+          { path: 'issue/detail/create', element: <WorkspaceIssueDetail initialMode="create" /> },
+          { path: 'issue/:issueId', element: <WorkspaceIssueDetail initialMode="view" /> },
+          { path: 'issue/:issueId/edit', element: <WorkspaceIssueDetail initialMode="edit" /> },
+
+          // 워크스페이스 목표 관련 라우트
           { path: 'goal', element: <WorkspaceGoal /> },
-          { path: 'goal/:goalId', element: <WorkspaceGoalDetail /> },
+          { path: 'goal/detail/create', element: <WorkspaceGoalDetail initialMode="create" /> },
+          { path: 'goal/:goalId', element: <WorkspaceGoalDetail initialMode="view" /> },
+          { path: 'goal/:goalId/edit', element: <WorkspaceGoalDetail initialMode="edit" /> },
+
+          // 워크스페이스 외부 관련 라우트
           { path: 'ext', element: <WorkspaceExternal /> },
-          { path: 'ext/:extId', element: <WorkspaceExternalDetail /> },
+          { path: 'ext/detail/create', element: <WorkspaceExternalDetail initialMode="create" /> },
+          { path: 'ext/:extId', element: <WorkspaceExternalDetail initialMode="view" /> },
+          { path: 'ext/:extId/edit', element: <WorkspaceExternalDetail initialMode="edit" /> },
         ],
       },
       /* 팀별 페이지들 */

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -27,7 +27,7 @@ export const protectedRoutes: RouteObject[] = [
     errorElement: <Error404NotFound />,
 
     children: [
-      { index: true, element: <WorkspaceIssue /> },
+      { index: true, element: <Navigate to="default/team/:teamId/issue" replace /> },
       /* 알람 페이지 */
       {
         path: 'noti',

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -69,10 +69,18 @@ export const protectedRoutes: RouteObject[] = [
         children: [
           // 기본 경로는 이슈 페이지로 리다이렉트.
           { index: true, element: <Navigate to="issue" replace /> },
+
+          // 목표 관련 라우트
           { path: 'goal', element: <GoalHome /> },
-          { path: 'goal/:goalId', element: <GoalDetail /> },
+          { path: 'goal/detail/create', element: <GoalDetail mode="create" /> },
+          { path: 'goal/:goalId', element: <GoalDetail mode="view" /> },
+          { path: 'goal/:goalId/edit', element: <GoalDetail mode="edit" /> },
+
+          // 이슈 관련 라우트
           { path: 'issue', element: <IssueHome /> },
           { path: 'issue/:issueId', element: <IssueDetail /> },
+
+          // 외부 연동 관련 라우트
           { path: 'ext', element: <ExternalHome /> },
           { path: 'ext/:extId', element: <ExternalDetail /> },
         ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -78,7 +78,9 @@ export const protectedRoutes: RouteObject[] = [
 
           // 이슈 관련 라우트
           { path: 'issue', element: <IssueHome /> },
-          { path: 'issue/:issueId', element: <IssueDetail /> },
+          { path: 'issue/detail/create', element: <IssueDetail initialMode="create" /> },
+          { path: 'issue/:issueId', element: <IssueDetail initialMode="view" /> },
+          { path: 'issue/:issueId/edit', element: <IssueDetail initialMode="edit" /> },
 
           // 외부 연동 관련 라우트
           { path: 'ext', element: <ExternalHome /> },

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -72,9 +72,9 @@ export const protectedRoutes: RouteObject[] = [
 
           // 목표 관련 라우트
           { path: 'goal', element: <GoalHome /> },
-          { path: 'goal/detail/create', element: <GoalDetail mode="create" /> },
-          { path: 'goal/:goalId', element: <GoalDetail mode="view" /> },
-          { path: 'goal/:goalId/edit', element: <GoalDetail mode="edit" /> },
+          { path: 'goal/detail/create', element: <GoalDetail initialMode="create" /> },
+          { path: 'goal/:goalId', element: <GoalDetail initialMode="view" /> },
+          { path: 'goal/:goalId/edit', element: <GoalDetail initialMode="edit" /> },
 
           // 이슈 관련 라우트
           { path: 'issue', element: <IssueHome /> },


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #96 

---

### ✅ Key Changes
**상세페이지의 생성/조회/수정 모드에 따라 url 구조를 분리하여 처리합니다.**
- `/workspace/team/:teamId/goal/detail/create` → (1) 생성모드_처음에 상세페이지 생성하여 작성 완료하기 전
- `/workspace/team/:teamId/goal/:goalId` → (2) 조회모드_작성 완료 후 상세페이지 조회할 때
- `/workspace/team/:teamId/goal/:goalId/edit` → (3) 수정모드_작성 완료 후 상세페이지를 다시 수정할 때
<br>

**이에 따라 ProtectedRoutes.tsx 파일 내에서의 라우팅 변경은 아래와 같이 바꾸었습니다.**
(예시: 목표 상세페이지 모드별 라우트 분리)

```
path: 'team/:teamId',
element: <Outlet />,
children: [
  // 기본 경로는 이슈 페이지로 리다이렉트.
  { index: true, element: <Navigate to="issue" replace /> },

  // 목표 관련 라우트
  { path: 'goal', element: <GoalHome /> },
  { path: 'goal/detail/create', element: <GoalDetail initialMode="create" /> },
  { path: 'goal/:goalId', element: <GoalDetail initialMode="view" /> },
  { path: 'goal/:goalId/edit', element: <GoalDetail initialMode="edit" /> },
],
```
- 위와 같이 initialMode라는 props를 새로 상세페이지에 정의하여 사용합니다.
- mode에 따라 하나의 상세페이지 url을 정확하게 분기하는 방식으로 구현했으므로, 상세페이지 컴포넌트 내부에서는 useParams()를 사용해 URL을 파싱하여 모드를 유추하는 방식 대신 props로 initialMode를 넘겨주는 방식으로 처리했습니다.
<br>

**상세페이지 내에서 모드별 동작을 제어하는 것은 `useToggleMode.ts` 커스텀 훅으로 처리했습니다.**
 - 생성 모드(create), 수정 모드(edit), 조회 모드(view) 간의 전환을 관리.
 - 모드별 URL 경로를 변경하여 페이지 전환을 처리.
- 해당 훅은 우측 하단의 '작성완료'<->'수정하기' 토글 버튼(`CompletionButton.tsx`)의 onToggle이라는 props에 연결됩니다.
- 파일 경로: `src/hooks` 폴더 내
<br>

**모드별 라우트 변경된 페이지들**
- 목표 상세페이지
- 이슈 상세페이지
- 외부 상세페이지
- 워크스페이스 기본 팀의 목표 상세페이지
- 워크스페이스 기본 팀의 이슈 상세페이지
- 워크스페이스 기본 팀의 외부 상세페이지
<br>

**+ 추가: 워크스페이스 기본 경로 수정**
@sunhwaaRj 님께서 기본 `/workspace` 경로로 이동했을 때의 워크스페이스 홈화면도 `teamId`가 경로상에 포함되어야 한다고 말씀해주셔서 아래와 같이 워크스페이스 내 기본 경로(index)를 수정했습니다.

```
path: '/workspace',
element: <ProtectedLayout />,
errorElement: <Error404NotFound />,

children: [
  { index: true, element: <Navigate to="default/team/:teamId/issue" replace /> },
```

---

### 📸 스크린샷 or 실행영상
1) 생성/조회/수정 모드별 화면 전환
2) 모드 전환될 때 상단 url 변경

=> 이 2가지를 중점적으로 봐주시면 됩니다.
<br>

(1) 목표 상세페이지

https://github.com/user-attachments/assets/215d9e11-849a-407c-a27f-cdee88425bdd

<br>

(2) 이슈 상세페이지

https://github.com/user-attachments/assets/39c4ec83-bb82-47d5-8246-3ba9a1b5aece



---

### 💬 To Reviewers

1. 모드별 전환이 잘 이루어지는지 테스트를 위해, 시범삼아 사이드바의 추가('+') 버튼에는 제가 직접 create 모드의 상세페이지 경로로 변경해두었습니다. 혹시 오류 없는지 봐주세요. @jinj00oo 

2. 그외의 실제 컴포넌트 or 페이지들에서 변경된 라우팅이 반영되도록, 각 담당자분들이 ProtectedRoutes.tsx 파일 참고하여 경로 변경해주세요. 특히 목록 페이지의 추가('+') 버튼에 create 모드의 상세페이지 경로로 변경하는 것 잊지 마세요. @sunhwaaRj 

3. 추후 api 연동하는 과정에서 상세페이지 모드 전환을 zustand로 관리하는 것으로 변경할 예정입니다. 가급적 이번주에 진행하겠습니다.