### PR TITLE
[FIX] 에러 페이지 상태코드 처리 수정

### DIFF
--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -169,9 +169,11 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                         }}
                         onAddClick={() => {
                           navigate(
-                            `/workspace/team/:teamId/goal/:goalId`
-                              .replace(':teamId', String(team.teamId))
-                              .replace(':goalId', String(123))
+                            // 바꾼 부분 여기임
+                            `/workspace/team/:teamId/goal/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
                           );
                         }}
                       />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -102,9 +102,10 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/:teamId/goal/:goalId`
-                          .replace(':teamId', String(1))
-                          .replace(':goalId', String(123))
+                        `/workspace/default/team/:teamId/goal/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
                       );
                     }}
                   />
@@ -119,9 +120,10 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/:teamId/issue/:issueId`
-                          .replace(':teamId', String(1))
-                          .replace(':issueId', String(123))
+                        `/workspace/default/team/:teamId/issue/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
                       );
                     }}
                   />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -187,9 +187,10 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                         }}
                         onAddClick={() => {
                           navigate(
-                            `/workspace/team/:teamId/issue/:issueId`
-                              .replace(':teamId', String(team.teamId))
-                              .replace(':issueId', String(123))
+                            `/workspace/team/:teamId/issue/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
                           );
                         }}
                       />

--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -169,7 +169,6 @@ const FullSidebarContent = ({ setExpanded, teams }: FullSidebarContentProps) => 
                         }}
                         onAddClick={() => {
                           navigate(
-                            // 바꾼 부분 여기임
                             `/workspace/team/:teamId/goal/detail/create`.replace(
                               ':teamId',
                               String(team.teamId)

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -77,7 +77,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                       navigate(`/workspace/team/default/goal`);
                     }}
                     onAddClick={() => {
-                      navigate(`/workspace/team/default/goal/:goalId`);
+                      navigate(
+                        `/workspace/default/team/:teamId/goal/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
+                      );
                     }}
                   />
                   <SidebarItem
@@ -88,7 +93,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                       navigate(`/workspace/team/default/issue`);
                     }}
                     onAddClick={() => {
-                      navigate(`/workspace/team/default/issue/:issueId`);
+                      navigate(
+                        `/workspace/default/team/:teamId/issue/detail/create`.replace(
+                          ':teamId',
+                          String(1)
+                        )
+                      );
                     }}
                   />
                   <SidebarItem
@@ -127,7 +137,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                           navigate(`/workspace/team/:teamId/goal`);
                         }}
                         onAddClick={() => {
-                          navigate(`/workspace/team/:teamId/goal/:goalId`);
+                          navigate(
+                            `/workspace/team/:teamId/goal/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
+                          );
                         }}
                       />
                       <SidebarItem
@@ -138,7 +153,12 @@ const MiniSidebarContent = ({ setExpanded, teams }: MiniSidebarContentProps) => 
                           navigate(`/workspace/team/:teamId/issue`);
                         }}
                         onAddClick={() => {
-                          navigate(`/workspace/team/:teamId/issue/:issueId`);
+                          navigate(
+                            `/workspace/team/:teamId/issue/detail/create`.replace(
+                              ':teamId',
+                              String(team.teamId)
+                            )
+                          );
                         }}
                       />
                       <SidebarItem

--- a/src/components/Sidebar/MiniSidebarContent.tsx
+++ b/src/components/Sidebar/MiniSidebarContent.tsx
@@ -109,7 +109,7 @@ const MiniSidebarContent = ({
                     }}
                     onAddClick={() => {
                       navigate(
-                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/goal/detai/create`
+                        `/workspace/default/team/${workspaceProfile.defaultTeamId}/goal/detail/create`
                       );
                     }}
                   />

--- a/src/hooks/useToggleMode.ts
+++ b/src/hooks/useToggleMode.ts
@@ -1,0 +1,48 @@
+/**
+ * 목표/이슈/외부 상세페이지에서 mode 전환을 위한 커스텀 훅
+ * - 생성 모드(create), 수정 모드(edit), 조회 모드(view) 간의 전환을 관리
+ * - 모드별 URL 경로를 변경하여 페이지 전환을 처리
+ */
+
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCallback } from 'react';
+
+type Mode = 'create' | 'view' | 'edit';
+
+interface UseToggleModeProps {
+  mode: Mode;
+  setMode: (mode: Mode) => void;
+  type: 'goal' | 'issue' | 'ext';
+  id: string;
+  isDefaultTeam: boolean;
+}
+
+export const useToggleMode = ({ mode, setMode, type, id, isDefaultTeam }: UseToggleModeProps) => {
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>();
+
+  const getBasePath = () => {
+    if (!teamId) return '';
+    return isDefaultTeam
+      ? `/workspace/default/team/${teamId}/${type}`
+      : `/workspace/team/${teamId}/${type}`;
+  };
+
+  const handleToggleMode = useCallback(() => {
+    const base = getBasePath();
+    if (!base) return;
+
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`${base}/${id}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`${base}/${id}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`${base}/${id}/edit`);
+    }
+  }, [mode, id, navigate, setMode, isDefaultTeam, teamId, type]);
+
+  return handleToggleMode;
+};

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -5,7 +5,7 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import Loading from '../pages/Loading.tsx';
-import Server500Error from '../pages/Server500Error.tsx';
+import ServerError from '../pages/ServerError.tsx';
 
 const ProtectedLayout = () => {
   const location = useLocation();
@@ -13,7 +13,7 @@ const ProtectedLayout = () => {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary onReset={reset} FallbackComponent={Server500Error}>
+        <ErrorBoundary onReset={reset} FallbackComponent={ServerError}>
           <Suspense fallback={<Loading />}>
             <div className="flex h-screen">
               <aside className="overflow-auto sidebar-scroll">

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -1,15 +1,15 @@
 import { Outlet } from 'react-router-dom';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
-import Server500Error from '../pages/Server500Error.tsx';
 import { Suspense } from 'react';
 import Loading from '../pages/Loading.tsx';
+import ServerError from '../pages/ServerError.tsx';
 
 const PublicLayout = () => {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary onReset={reset} FallbackComponent={Server500Error}>
+        <ErrorBoundary onReset={reset} FallbackComponent={ServerError}>
           <Suspense fallback={<Loading />}>
             <main className="w-full h-screen overflow-auto basic-scroll bg-gray-onboard">
               <div className="min-w-max min-h-screen flex flex-col items-center justify-center">

--- a/src/pages/ServerError.tsx
+++ b/src/pages/ServerError.tsx
@@ -1,8 +1,35 @@
 import { useNavigate } from 'react-router-dom';
 import PrimaryButton from '../components/Onboarding/PrimaryButton.tsx';
+import type { FallbackProps } from 'react-error-boundary';
+import type { AxiosError } from 'axios';
 
-const ServerError = () => {
+const ServerError = ({ error, resetErrorBoundary }: FallbackProps) => {
   const navigate = useNavigate();
+
+  // AxiosError인지 확인
+  const isAxiosError = (err: unknown): err is AxiosError => {
+    return (err as AxiosError)?.isAxiosError === true;
+  };
+
+  // 상태 코드 추출
+  const statusCode = isAxiosError(error) ? error.response?.status : null;
+
+  const getErrorMessage = () => {
+    switch (statusCode) {
+      case 400:
+        return '잘못된 요청입니다.';
+      case 401:
+        return '인증되지 않은 사용자입니다.';
+      case 403:
+        return '접근이 거부되었습니다.';
+      case 404:
+        return '요청한 리소스를 찾을 수 없습니다.';
+      case 500:
+        return '서버 오류가 발생했습니다.';
+      default:
+        return '알 수 없는 오류가 발생했습니다.';
+    }
+  };
 
   return (
     <div className="flex flex-col w-full h-dvh items-center justify-center bg-gray-onboard">
@@ -10,9 +37,11 @@ const ServerError = () => {
         <div className="flex flex-col items-center gap-[10.8rem]">
           {/* 에러 문구 */}
           <div className="flex flex-col gap-[3.2rem] text-center">
-            <h2 className="font-bigtitle-b text-gray-600">Error</h2>
+            <h2 className="font-bigtitle-b text-gray-600">
+              {statusCode ? `${statusCode} Error` : 'Error'}
+            </h2>
             <h3 className="font-title-sub-r text-gray-600">
-              서버 오류가 발생했습니다.
+              {getErrorMessage()}
               <br /> 잠시 후 다시 시도해 주세요!
             </h3>
           </div>
@@ -20,6 +49,8 @@ const ServerError = () => {
           <PrimaryButton
             text="돌아가기"
             onClick={() => {
+              resetErrorBoundary();
+              // 뒤로 가기 및 새로고침
               navigate(-1);
               window.location.reload();
             }}

--- a/src/pages/ServerError.tsx
+++ b/src/pages/ServerError.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import PrimaryButton from '../components/Onboarding/PrimaryButton.tsx';
 
-const Server500Error = () => {
+const ServerError = () => {
   const navigate = useNavigate();
 
   return (
@@ -10,7 +10,7 @@ const Server500Error = () => {
         <div className="flex flex-col items-center gap-[10.8rem]">
           {/* 에러 문구 */}
           <div className="flex flex-col gap-[3.2rem] text-center">
-            <h2 className="font-bigtitle-b text-gray-600">500</h2>
+            <h2 className="font-bigtitle-b text-gray-600">Error</h2>
             <h3 className="font-title-sub-r text-gray-600">
               서버 오류가 발생했습니다.
               <br /> 잠시 후 다시 시도해 주세요!
@@ -30,4 +30,4 @@ const Server500Error = () => {
   );
 };
 
-export default Server500Error;
+export default ServerError;

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -53,13 +53,13 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   const handleToggleMode = () => {
     if (mode === 'create') {
       setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeExtId}`);
+      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
     } else if (mode === 'edit') {
       setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeExtId}`);
+      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
     } else if (mode === 'view') {
       setMode('edit');
-      navigate(`/workspace/team/${teamId}/issue/${fakeExtId}/edit`);
+      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}/edit`);
     }
   };
 

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -27,9 +27,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface ExternalDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -24,7 +24,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -39,9 +39,6 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeExtId = '123'; // 임시 extId (TODO: 실제로는 외부이슈 작성 API로부터 받아온 result의 extId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -50,18 +47,13 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/team/${teamId}/ext/${fakeExtId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'ext',
+    id: fakeExtId,
+    isDefaultTeam: false,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -24,6 +24,8 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useGetGoalName } from '../../apis/goal/useGetGoalName';
 
 /**
  * 구현 완료하면 이 주석은 지운다.
@@ -37,20 +39,37 @@ import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 // (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
 // (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
 interface GoalDetailProps {
-  mode: 'create' | 'view' | 'edit';
+  initialMode: 'create' | 'view' | 'edit';
 }
 
-const GoalDetail = ({ mode }: GoalDetailProps) => {
+const GoalDetail = ({ initialMode }: GoalDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
+
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string; goalId: string }>(); // URL 파라미터에서 teamId와 goalId 가져오기
+  const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown, closeDropdown } = useDropdownActions();
 
-  // 상태에 따라 작성 완료 버튼의 상태 결정
-  const [isCompleted, setIsCompleted] = useState(mode === 'view');
-  const isEditable = mode === 'create' || mode === 'edit';
-  const isTitleFilled = title.trim().length > 0;
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -78,10 +97,6 @@ const GoalDetail = ({ mode }: GoalDetailProps) => {
     전시현: IcProfile,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -96,11 +111,11 @@ const GoalDetail = ({ mode }: GoalDetailProps) => {
             defaultTitle="목표를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -199,11 +214,11 @@ const GoalDetail = ({ mode }: GoalDetailProps) => {
             </div>
           </div>
 
-          {/* 작성 완료 버튼 */}
+          {/* 작성 완료 버튼 : 상세페이지 mode 전환을 관리 */}
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -25,16 +25,32 @@ import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 
-const GoalDetail = () => {
+/**
+ * 구현 완료하면 이 주석은 지운다.
+ * - 생성 모드: 댓글창 안 보임 + 제목&상세설명 작성 가능 + 작성 완료 버튼으로 떠있음(초기 비활성화->제목 입력 후 활성화됨)
+ * - 조회 모드: 댓글창 보임 + 제목&상세설명 수정 불가 + 수정하기 버튼으로 떠있음(활성화)
+ * - 수정 모드: 댓글창 안 보임 + 제목&상세설명 수정 가능 + 작성 완료 버튼으로 떠있음(활성화)
+ */
+
+// 상세페이지 모드 구분
+// (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+// (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+// (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+interface GoalDetailProps {
+  mode: 'create' | 'view' | 'edit';
+}
+
+const GoalDetail = ({ mode }: GoalDetailProps) => {
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
-
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
-
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown, closeDropdown } = useDropdownActions();
+
+  // 상태에 따라 작성 완료 버튼의 상태 결정
+  const [isCompleted, setIsCompleted] = useState(mode === 'view');
+  const isEditable = mode === 'create' || mode === 'edit';
+  const isTitleFilled = title.trim().length > 0;
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -61,9 +77,6 @@ const GoalDetail = () => {
     전채운: IcProfile,
     전시현: IcProfile,
   };
-
-  // const dateIconMap = IcDate; // '기한' 속성 아이콘 매핑
-  // const issueIconMap = IcIssue; // '이슈' 속성 아이콘 매핑
 
   const handleToggle = () => {
     setIsCompleted((prev) => !prev);

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -26,10 +26,11 @@ import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useNavigate, useParams } from 'react-router-dom';
 
-// 상세페이지 모드 구분
-// (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
-// (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
-// (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
 interface GoalDetailProps {
   initialMode: 'create' | 'view' | 'edit';
 }
@@ -41,7 +42,7 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   const [option, setOption] = useState<string>('이슈');
 
   const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string; goalId: string }>(); // URL 파라미터에서 teamId와 goalId 가져오기
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -24,7 +24,7 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -40,9 +40,6 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -51,18 +48,13 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/team/${teamId}/goal/${fakeGoalId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'goal',
+    id: fakeGoalId,
+    isDefaultTeam: false,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -25,14 +25,6 @@ import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useGetGoalName } from '../../apis/goal/useGetGoalName';
-
-/**
- * 구현 완료하면 이 주석은 지운다.
- * - 생성 모드: 댓글창 안 보임 + 제목&상세설명 작성 가능 + 작성 완료 버튼으로 떠있음(초기 비활성화->제목 입력 후 활성화됨)
- * - 조회 모드: 댓글창 보임 + 제목&상세설명 수정 불가 + 수정하기 버튼으로 떠있음(활성화)
- * - 수정 모드: 댓글창 안 보임 + 제목&상세설명 수정 가능 + 작성 완료 버튼으로 떠있음(활성화)
- */
 
 // 상세페이지 모드 구분
 // (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -27,9 +27,9 @@ import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface GoalDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/goal/GoalHome.tsx
+++ b/src/pages/goal/GoalHome.tsx
@@ -17,7 +17,7 @@ import { useGetInfiniteGoalList } from '../../apis/goal/useGetGoalList';
 import { useDeleteGoals } from '../../apis/goal/useDeleteGoals';
 import ListViewItemSkeletonList from '../../components/ListView/ListViewItemSkeletonList';
 import { mergeGroups } from '../../components/ListView/MergeGroup';
-import Server500Error from '../Server500Error';
+import Server500Error from '../ServerError';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자'] as const;
 

--- a/src/pages/goal/GoalHome.tsx
+++ b/src/pages/goal/GoalHome.tsx
@@ -125,12 +125,7 @@ const GoalHome = () => {
   };
 
   if (isError) {
-    return (
-      <ServerError
-        error={new Error('목표 데이터를 불러오는 중 오류가 발생했습니다.')}
-        resetErrorBoundary={() => window.location.reload()}
-      />
-    );
+    return <ServerError error={new Error()} resetErrorBoundary={() => window.location.reload()} />;
   }
 
   return (

--- a/src/pages/goal/GoalHome.tsx
+++ b/src/pages/goal/GoalHome.tsx
@@ -17,7 +17,7 @@ import { useGetInfiniteGoalList } from '../../apis/goal/useGetGoalList';
 import { useDeleteGoals } from '../../apis/goal/useDeleteGoals';
 import ListViewItemSkeletonList from '../../components/ListView/ListViewItemSkeletonList';
 import { mergeGroups } from '../../components/ListView/MergeGroup';
-import Server500Error from '../ServerError';
+import ServerError from '../ServerError';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자'] as const;
 
@@ -125,7 +125,12 @@ const GoalHome = () => {
   };
 
   if (isError) {
-    return <Server500Error />;
+    return (
+      <ServerError
+        error={new Error('목표 데이터를 불러오는 중 오류가 발생했습니다.')}
+        resetErrorBoundary={() => window.location.reload()}
+      />
+    );
   }
 
   return (

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -23,16 +23,44 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const IssueDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface IssueDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const IssueDetail = ({ initialMode }: IssueDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
 
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeIssueId = '123'; // 임시 issueId (TODO: 실제로는 이슈 작성 API로부터 받아온 result의 issueId 값을 사용 예정)
 
-  const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
-  const { openDropdown } = useDropdownActions();
+  const { isOpen, content } = useDropdownInfo(); // 작성 완료 여부 (view 모드일 때 true)
+  const { openDropdown } = useDropdownActions(); // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -67,10 +95,6 @@ const IssueDetail = () => {
     '기획 및 요구사항 분석': IcGoal,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -85,11 +109,11 @@ const IssueDetail = () => {
             defaultTitle="이슈를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -173,7 +197,7 @@ const IssueDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -23,7 +23,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -38,9 +38,6 @@ const IssueDetail = ({ initialMode }: IssueDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeIssueId = '123'; // 임시 issueId (TODO: 실제로는 이슈 작성 API로부터 받아온 result의 issueId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 작성 완료 여부 (view 모드일 때 true)
@@ -49,18 +46,13 @@ const IssueDetail = ({ initialMode }: IssueDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/team/${teamId}/issue/${fakeIssueId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'issue',
+    id: fakeIssueId,
+    isDefaultTeam: false,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -26,9 +26,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface IssueDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/issue/IssueHome.tsx
+++ b/src/pages/issue/IssueHome.tsx
@@ -17,7 +17,7 @@ import { useDeleteIssues } from '../../apis/issue/useDeleteIssues';
 import { mergeGroups } from '../../components/ListView/MergeGroup';
 import { useInView } from 'react-intersection-observer';
 import ListViewItemSkeletonList from '../../components/ListView/ListViewItemSkeletonList';
-import Server500Error from '../ServerError';
+import ServerError from '../ServerError';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자', '목표'] as const;
 
@@ -127,7 +127,12 @@ const IssueHome = () => {
   };
 
   if (isError) {
-    return <Server500Error />;
+    return (
+      <ServerError
+        error={new Error('이슈 데이터를 불러오는 중 오류가 발생했습니다.')}
+        resetErrorBoundary={() => window.location.reload()}
+      />
+    );
   }
 
   return (

--- a/src/pages/issue/IssueHome.tsx
+++ b/src/pages/issue/IssueHome.tsx
@@ -17,7 +17,7 @@ import { useDeleteIssues } from '../../apis/issue/useDeleteIssues';
 import { mergeGroups } from '../../components/ListView/MergeGroup';
 import { useInView } from 'react-intersection-observer';
 import ListViewItemSkeletonList from '../../components/ListView/ListViewItemSkeletonList';
-import Server500Error from '../Server500Error';
+import Server500Error from '../ServerError';
 
 const FILTER_OPTIONS: ItemFilter[] = ['상태', '우선순위', '담당자', '목표'] as const;
 

--- a/src/pages/issue/IssueHome.tsx
+++ b/src/pages/issue/IssueHome.tsx
@@ -127,12 +127,7 @@ const IssueHome = () => {
   };
 
   if (isError) {
-    return (
-      <ServerError
-        error={new Error('이슈 데이터를 불러오는 중 오류가 발생했습니다.')}
-        resetErrorBoundary={() => window.location.reload()}
-      />
-    );
+    return <ServerError error={new Error()} resetErrorBoundary={() => window.location.reload()} />;
   }
 
   return (

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -27,9 +27,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface WorkspaceExternalDetailProps {
   initialMode: 'create' | 'view' | 'edit';
@@ -39,7 +39,7 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+  const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 외부이슈 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -1,5 +1,5 @@
 // WorkspaceExternalDetail.tsx
-// 워크스페이스 전체 팀 외부 상세페이지
+// 워크스페이스 전체 팀 - 외부 상세페이지
 
 import { useState } from 'react';
 import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
@@ -24,16 +24,44 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const WorkspaceExternalDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface WorkspaceExternalDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
 
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -75,10 +103,6 @@ const WorkspaceExternalDetail = () => {
     Github: IcExt,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -93,11 +117,11 @@ const WorkspaceExternalDetail = () => {
             defaultTitle="제목을 작성해보세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -190,7 +214,7 @@ const WorkspaceExternalDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -24,7 +24,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -39,9 +39,6 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeExtId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -50,18 +47,13 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/default/team/${teamId}/ext/${fakeExtId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'ext',
+    id: fakeExtId,
+    isDefaultTeam: true,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -27,9 +27,9 @@ import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface WorkspaceGoalDetailProps {
   initialMode: 'create' | 'view' | 'edit';

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -1,5 +1,5 @@
 // WorkspaceGoalDetail.tsx
-// 워크스페이스 전체 팀 목표 상세페이지
+// 워크스페이스 전체 팀 - 목표 상세페이지
 
 import { useState } from 'react';
 import WorkspaceDetailHeader from '../../components/DetailView/WorkspaceDetailHeader';
@@ -24,17 +24,45 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const WorkspaceGoalDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface WorkspaceGoalDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
-
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
-
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
+
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown, closeDropdown } = useDropdownActions();
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -62,13 +90,6 @@ const WorkspaceGoalDetail = () => {
     전시현: IcProfile,
   };
 
-  // const dateIconMap = IcDate; // '기한' 속성 아이콘 매핑
-  // const issueIconMap = IcIssue; // '이슈' 속성 아이콘 매핑
-
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -83,11 +104,11 @@ const WorkspaceGoalDetail = () => {
             defaultTitle="목표를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -190,7 +211,7 @@ const WorkspaceGoalDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -24,7 +24,7 @@ import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
 import ArrowDropdown from '../../components/Dropdown/ArrowDropdown';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -40,9 +40,6 @@ const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
   const [option, setOption] = useState<string>('이슈');
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeGoalId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -51,18 +48,13 @@ const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/default/team/${teamId}/goal/${fakeGoalId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'goal',
+    id: fakeGoalId,
+    isDefaultTeam: true,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -23,7 +23,7 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
  * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
@@ -38,9 +38,6 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-
-  const navigate = useNavigate();
-  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
   const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
@@ -49,18 +46,13 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
   const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
 
-  const handleToggleMode = () => {
-    if (mode === 'create') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'edit') {
-      setMode('view');
-      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
-    } else if (mode === 'view') {
-      setMode('edit');
-      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}/edit`);
-    }
-  };
+  const handleToggleMode = useToggleMode({
+    mode,
+    setMode,
+    type: 'issue',
+    id: fakeIssueId,
+    isDefaultTeam: true,
+  });
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -23,16 +23,44 @@ import CommentSection from '../../components/DetailView/Comment/CommentSection';
 import CalendarDropdown from '../../components/Calendar/CalendarDropdown';
 import { useDropdownActions, useDropdownInfo } from '../../hooks/useDropdown';
 import { formatDateDot } from '../../utils/formatDate';
+import { useNavigate, useParams } from 'react-router-dom';
 
-const WorkspaceIssueDetail = () => {
+/** 상세페이지 모드 구분
+ * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ */
+interface WorkspaceIssueDetailProps {
+  initialMode: 'create' | 'view' | 'edit';
+}
+
+const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
+  const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
 
-  // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]);
+  const navigate = useNavigate();
+  const { teamId } = useParams<{ teamId: string }>(); // URL 파라미터에서 teamId 가져오기
+  const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();
+
+  const isCompleted = mode === 'view'; // 작성 완료 여부 (view 모드일 때 true)
+  const isEditable = mode === 'create' || mode === 'edit'; // 수정 가능 여부 (create 또는 edit 모드일 때 true)
+
+  const handleToggleMode = () => {
+    if (mode === 'create') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'edit') {
+      setMode('view');
+      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}`);
+    } else if (mode === 'view') {
+      setMode('edit');
+      navigate(`/workspace/default/team/${teamId}/issue/${fakeIssueId}/edit`);
+    }
+  };
 
   // '기한' 속성의 텍스트(시작일, 종료일) 결정하는 함수
   const getDisplayText = () => {
@@ -67,10 +95,6 @@ const WorkspaceIssueDetail = () => {
     '기획 및 요구사항 분석': IcGoal,
   };
 
-  const handleToggle = () => {
-    setIsCompleted((prev) => !prev);
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] pb-[5.3rem]">
       {/* 상세페이지 헤더 */}
@@ -85,11 +109,11 @@ const WorkspaceIssueDetail = () => {
             defaultTitle="이슈를 생성하세요"
             title={title}
             setTitle={setTitle}
-            isEditable={!isCompleted}
+            isEditable={isEditable}
           />
 
           {/* 상세 설명 작성 컴포넌트 */}
-          <DetailTextEditor isEditable={!isCompleted} />
+          <DetailTextEditor isEditable={isEditable} />
 
           {/* 댓글 영역 */}
           {isCompleted && <CommentSection />}
@@ -173,7 +197,7 @@ const WorkspaceIssueDetail = () => {
           <CompletionButton
             isTitleFilled={title.trim().length > 0}
             isCompleted={isCompleted}
-            onToggle={handleToggle}
+            onToggle={handleToggleMode}
           />
         </div>
       </div>

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -26,9 +26,9 @@ import { formatDateDot } from '../../utils/formatDate';
 import { useToggleMode } from '../../hooks/useToggleMode';
 
 /** 상세페이지 모드 구분
- * (1) create - 생성 모드: 처음에 목표를 생성하여 작성 완료하기 전
- * (2) view - 조회 모드: 작성 완료 후 목표 조회할 때
- * (3) edit - 수정 모드: 작성 완료 후 목표를 다시 수정할 때
+ * (1) create - 생성 모드: 처음에 생성하여 작성 완료하기 전
+ * (2) view - 조회 모드: 작성 완료 후 조회할 때
+ * (3) edit - 수정 모드: 작성 완료 후 다시 수정할 때
  */
 interface WorkspaceIssueDetailProps {
   initialMode: 'create' | 'view' | 'edit';
@@ -38,7 +38,7 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   const [mode, setMode] = useState<'create' | 'view' | 'edit'>(initialMode); // 상세페이지 모드 상태
   const [title, setTitle] = useState('');
   const [selectedDate, setSelectedDate] = useState<[Date | null, Date | null]>([null, null]); // '기한' 속성의 달력 드롭다운: 시작일, 종료일 2개를 저장
-  const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 목표 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
+  const fakeIssueId = '123'; // 임시 goalId (TODO: 실제로는 이슈 작성 API로부터 받아온 result의 goalId 값을 사용 예정)
 
   const { isOpen, content } = useDropdownInfo(); // 현재 드롭다운의 열림 여부와 내용 가져옴
   const { openDropdown } = useDropdownActions();

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -84,7 +84,9 @@ export const protectedRoutes: RouteObject[] = [
 
           // 외부 연동 관련 라우트
           { path: 'ext', element: <ExternalHome /> },
-          { path: 'ext/:extId', element: <ExternalDetail /> },
+          { path: 'ext/detail/create', element: <ExternalDetail initialMode="create" /> },
+          { path: 'ext/:extId', element: <ExternalDetail initialMode="view" /> },
+          { path: 'ext/:extId/edit', element: <ExternalDetail initialMode="edit" /> },
         ],
       },
     ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -54,12 +54,24 @@ export const protectedRoutes: RouteObject[] = [
         children: [
           // 기본 경로는 이슈 페이지로 리다이렉트
           { index: true, element: <Navigate to="issue" replace /> },
+
+          // 워크스페이스 이슈 관련 라우트
           { path: 'issue', element: <WorkspaceIssue /> },
-          { path: 'issue/:issueId', element: <WorkspaceIssueDetail /> },
+          { path: 'issue/detail/create', element: <WorkspaceIssueDetail initialMode="create" /> },
+          { path: 'issue/:issueId', element: <WorkspaceIssueDetail initialMode="view" /> },
+          { path: 'issue/:issueId/edit', element: <WorkspaceIssueDetail initialMode="edit" /> },
+
+          // 워크스페이스 목표 관련 라우트
           { path: 'goal', element: <WorkspaceGoal /> },
-          { path: 'goal/:goalId', element: <WorkspaceGoalDetail /> },
+          { path: 'goal/detail/create', element: <WorkspaceGoalDetail initialMode="create" /> },
+          { path: 'goal/:goalId', element: <WorkspaceGoalDetail initialMode="view" /> },
+          { path: 'goal/:goalId/edit', element: <WorkspaceGoalDetail initialMode="edit" /> },
+
+          // 워크스페이스 외부 관련 라우트
           { path: 'ext', element: <WorkspaceExternal /> },
-          { path: 'ext/:extId', element: <WorkspaceExternalDetail /> },
+          { path: 'ext/detail/create', element: <WorkspaceExternalDetail initialMode="create" /> },
+          { path: 'ext/:extId', element: <WorkspaceExternalDetail initialMode="view" /> },
+          { path: 'ext/:extId/edit', element: <WorkspaceExternalDetail initialMode="edit" /> },
         ],
       },
       /* 팀별 페이지들 */

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -3,7 +3,6 @@ import ProtectedLayout from '../layouts/ProtectedLayout';
 import GoalHome from '../pages/goal/GoalHome';
 import IssueHome from '../pages/issue/IssueHome';
 import NotiHome from '../pages/notification/NotiHome';
-import Error404NotFound from '../pages/Error404NotFound';
 import SettingTeam from '../pages/setting/SettingTeam.tsx';
 import SettingMember from '../pages/setting/SettingMember.tsx';
 import SettingMyProfile from '../pages/setting/SettingMyProfile.tsx';
@@ -18,13 +17,24 @@ import ExternalDetail from '../pages/external/ExternalDetail.tsx';
 import WorkspaceGoalDetail from '../pages/workspace/WorkspaceGoalDetail.tsx';
 import WorkspaceIssueDetail from '../pages/workspace/WorkspaceIssueDetail.tsx';
 import WorkspaceExternalDetail from '../pages/workspace/WorkspaceExternalDetail.tsx';
+import ServerError from '../pages/ServerError.tsx';
 
 export const protectedRoutes: RouteObject[] = [
   {
     // 워크스페이스 내부 페이지들 : 로그인해야 들어올 수 있음
     path: '/workspace',
     element: <ProtectedLayout />,
-    errorElement: <Error404NotFound />,
+    errorElement: (
+      <ServerError
+        error={
+          {
+            isAxiosError: true,
+            response: { status: 500 },
+          } as any
+        }
+        resetErrorBoundary={() => window.location.reload()}
+      />
+    ),
 
     children: [
       { index: true, element: <Navigate to="default/team/:teamId/issue" replace /> },

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -27,7 +27,7 @@ export const protectedRoutes: RouteObject[] = [
     errorElement: <Error404NotFound />,
 
     children: [
-      { index: true, element: <WorkspaceIssue /> },
+      { index: true, element: <Navigate to="default/team/:teamId/issue" replace /> },
       /* 알람 페이지 */
       {
         path: 'noti',

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -69,10 +69,18 @@ export const protectedRoutes: RouteObject[] = [
         children: [
           // 기본 경로는 이슈 페이지로 리다이렉트.
           { index: true, element: <Navigate to="issue" replace /> },
+
+          // 목표 관련 라우트
           { path: 'goal', element: <GoalHome /> },
-          { path: 'goal/:goalId', element: <GoalDetail /> },
+          { path: 'goal/detail/create', element: <GoalDetail mode="create" /> },
+          { path: 'goal/:goalId', element: <GoalDetail mode="view" /> },
+          { path: 'goal/:goalId/edit', element: <GoalDetail mode="edit" /> },
+
+          // 이슈 관련 라우트
           { path: 'issue', element: <IssueHome /> },
           { path: 'issue/:issueId', element: <IssueDetail /> },
+
+          // 외부 연동 관련 라우트
           { path: 'ext', element: <ExternalHome /> },
           { path: 'ext/:extId', element: <ExternalDetail /> },
         ],

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -78,7 +78,9 @@ export const protectedRoutes: RouteObject[] = [
 
           // 이슈 관련 라우트
           { path: 'issue', element: <IssueHome /> },
-          { path: 'issue/:issueId', element: <IssueDetail /> },
+          { path: 'issue/detail/create', element: <IssueDetail initialMode="create" /> },
+          { path: 'issue/:issueId', element: <IssueDetail initialMode="view" /> },
+          { path: 'issue/:issueId/edit', element: <IssueDetail initialMode="edit" /> },
 
           // 외부 연동 관련 라우트
           { path: 'ext', element: <ExternalHome /> },

--- a/src/routes/ProtectedRoutes.tsx
+++ b/src/routes/ProtectedRoutes.tsx
@@ -72,9 +72,9 @@ export const protectedRoutes: RouteObject[] = [
 
           // 목표 관련 라우트
           { path: 'goal', element: <GoalHome /> },
-          { path: 'goal/detail/create', element: <GoalDetail mode="create" /> },
-          { path: 'goal/:goalId', element: <GoalDetail mode="view" /> },
-          { path: 'goal/:goalId/edit', element: <GoalDetail mode="edit" /> },
+          { path: 'goal/detail/create', element: <GoalDetail initialMode="create" /> },
+          { path: 'goal/:goalId', element: <GoalDetail initialMode="view" /> },
+          { path: 'goal/:goalId/edit', element: <GoalDetail initialMode="edit" /> },
 
           // 이슈 관련 라우트
           { path: 'issue', element: <IssueHome /> },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,13 +1,26 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { publicRoutes } from './PublicRoutes';
 import { protectedRoutes } from './ProtectedRoutes';
-import Error404NotFound from '../pages/Error404NotFound';
+import ServerError from '../pages/ServerError';
 
 const router = createBrowserRouter([
   ...publicRoutes,
   ...protectedRoutes,
-  // 모든 잘못된 경로는 Not Found로 처리
-  { path: '*', element: <Error404NotFound /> },
+  // 모든 잘못된 경로는 ServerError 컴포넌트로 처리
+  {
+    path: '*',
+    element: (
+      <ServerError
+        error={
+          {
+            isAxiosError: true,
+            response: { status: 404 },
+          } as any
+        } // 최소 타입 충돌 방지를 위한 캐스팅
+        resetErrorBoundary={() => window.location.reload()}
+      />
+    ),
+  },
 ]);
 
 export default router;


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #141 

---

### ✅ Key Changes
**현재 404, 400 에러 등 500 에러가 아닌 상황에서도 `Server500Error.tsx`가 화면에 나타나는 문제가 발생합니다. 따라서 해당 에러 페이지에서 500 문구를 삭제하고, http 상태코드를 추출하여 화면에 에러메시지를 렌더링하는 방식으로 수정합니다.**

- `Server500Error.tsx` 페이지명을 `ServerError.tsx`로 변경 (500 에러가 아닌 경우에도 범용적으로 사용 가능한 에러 페이지)

- `isAxiosError` 타입 가드를 통해 `AxiosError`인지 안전하게 확인하도록 코드 추가
  ```
  // AxiosError인지 확인
  const isAxiosError = (err: unknown): err is AxiosError => {
    return (err as AxiosError)?.isAxiosError === true;
  };
  ```

- http 상태코드 추출하는 방식을 사용하여 각 경우별로 에러메시지를 다르게 렌더링하도록 수정

- `GoalHome.tsx`, `IssueHome.tsx` 등에 에러 발생시 호출하게 되는 `ServerError` 컴포넌트에 props 연결:
  ```
   if (isError) {
    return <ServerError error={new Error()} resetErrorBoundary={() => window.location.reload()} />;
  }
  ```

<br>

**주요 변경된 파일(아래 파일들의 변경사항만 보시면 됩니다):**
- `src/routes/index.tsx`
- `src/layouts/ProtectedLayout.tsx`
- `src/layouts/PublicLayout.tsx`
- `src/pages/ServerError.tsx`
- `src/pages/goal/GoalHome.tsx`
- `src/pages/issue/IssueHome.tsx`

---

### 📸 스크린샷 or 실행영상

에러 발생시 상태코드를 추출하여 해당 에러페이지에서 에러메시지를 다르게 렌더링하는 것을 보실 수 있습니다.

예시1) 400 에러일 때
<img width="1548" height="1146" alt="스크린샷 2025-08-08 오전 10 17 37" src="https://github.com/user-attachments/assets/df271529-db7b-410b-b846-066debbd8625" />

<br>

예시2) 404 에러일 때
<img width="1548" height="1146" alt="스크린샷 2025-08-08 오전 10 17 57" src="https://github.com/user-attachments/assets/a45cda1a-e23e-45fc-9a80-f8003ed25624" />


---

### 💬 To Reviewers

- 현재는 사용자가 에러 페이지 내의 '돌아가기' 버튼을 누르면 reset()이 호출되면서 query 상태도 초기화되어 다시 요청 가능해지는 구조를 사용하고 있으므로, `ProtectedLayout.tsx`와 `PublicLayout.tsx`에서 QueryErrorResetBoundary 처리를 없애지는 않았습니다.

<br>

- **온보딩 단계의 `Error404NotFound.tsx`와 해당 `ServerError.tsx`의 분리 제안** @waldls 
  - 새로 업데이트한 `ServerError.tsx`와의 분리를 위해 해당 파일명을 `Error404NotFound.tsx` -> `OnboardingError404NotFound.tsx`로 변경하여 온보딩 단계에서만 제한적으로 사용되는 파일임을 나타내거나
  - 온보딩 단계에서의 404 에러 처리도 해당 `ServerError.tsx` 파일로 처리하도록 변경하는 것이 어떨지 제안 드립니다.
  - 둘중에 어떤 것이 좋을지 생각해보시고 답변 주세요!

<br>

- 에러 발생시 처리 코드가 목표/이슈 목록 페이지에는 포함되어있어, 우선 해당 페이지들에만 코드 처리를 수정해두었습니다. 혹시 다른 목록 페이지들(외부 목록, 워크스페이스 기본 팀의 목표/이슈/외부 목록)에는 해당 에러 처리를 할 필요는 없나요? @sunhwaaRj 