### PR TITLE
[FEAT] 로그인 완료 시 리다이렉트 기능 구현

### DIFF
--- a/src/pages/workspace/WorkspaceComplete.tsx
+++ b/src/pages/workspace/WorkspaceComplete.tsx
@@ -1,11 +1,20 @@
+import { useGetWorkspaceProfile } from '../../apis/setting/useGetWorkspaceProfile.ts';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 const WorkspaceComplete = () => {
-  return (
-    <div className="min-w-max min-h-screen flex flex-col items-center justify-center">
-      <h3 className="font-title-sub-r text-gray-600">
-        워크스페이스 생성 및 참여가 완료되었습니다.
-      </h3>
-    </div>
-  );
+  const { data } = useGetWorkspaceProfile();
+  const teamId = data?.defaultTeamId;
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (teamId !== undefined) {
+      // 팀 ID를 사용하여 워크스페이스 페이지로 리다이렉트
+      navigate('/workspace/default/team/:teamId/issue'.replace(':teamId', String(teamId)), {
+        replace: true,
+      });
+    }
+  }, [teamId]);
+  return <div />;
 };
 
 export default WorkspaceComplete;


### PR DESCRIPTION
### 체크리스트

- [ ] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [ ] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [ ] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #154 

---

### ✅ Key Changes

- WorkspaceComplete.tsx 에서 getWorkspaceProfile API로 teamId 가져와서 리다이렉트

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
https://github.com/user-attachments/assets/ce6511f4-cb2d-4a13-826f-56328f3a806c


---

### 💬 To Reviewers
<!-- 팀원들에게 전달하고 싶은 말이나 노티해야되는 내용을 적어주세요. -->
따로 UI는 만들지 않았습니다.