### PR TITLE
[REFACTOR] Protected Routes 접근 권한 로직 수정

### DIFF
--- a/src/apis/setting/useGetWorkspaceProfile.ts
+++ b/src/apis/setting/useGetWorkspaceProfile.ts
@@ -3,6 +3,7 @@ import { axiosInstance } from '../axios';
 import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey';
 import { LOCAL_STORAGE_KEY } from '../../constants/key.ts';
+import { useLocalStorage } from '../../hooks/useLocalStorage.ts';
 
 // 설정 - 워크스페이스 프로필 조회
 // - src/pages/onboarding/TokenLoading.tsx
@@ -21,14 +22,15 @@ export const useGetWorkspaceProfile = () => {
     queryKey: [queryKey.WORKSPACE_PROFILE],
     queryFn: getWorkspaceProfile,
     select: (data) => {
-      const inviteUrl = localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl);
-      const invitePassword = localStorage.getItem(LOCAL_STORAGE_KEY.invitePassword);
-      if (!inviteUrl) {
-        localStorage.setItem(LOCAL_STORAGE_KEY.inviteUrl, data.workspaceUrl);
-      }
-      if (!invitePassword) {
-        localStorage.setItem(LOCAL_STORAGE_KEY.invitePassword, data.invitePassword);
-      }
+      const { setItem: setInviteUrl, getItem: getInviteUrl } = useLocalStorage(
+        LOCAL_STORAGE_KEY.inviteUrl
+      );
+      const { setItem: setInvitePassword, getItem: getInvitePassword } = useLocalStorage(
+        LOCAL_STORAGE_KEY.invitePassword
+      );
+
+      if (!getInviteUrl()) setInviteUrl(data.workspaceUrl);
+      if (!getInvitePassword()) setInvitePassword(data.invitePassword);
       return data;
     },
   });

--- a/src/apis/setting/useGetWorkspaceProfile.ts
+++ b/src/apis/setting/useGetWorkspaceProfile.ts
@@ -2,6 +2,7 @@ import type { WorkspaceResponse } from '../../types/setting';
 import { axiosInstance } from '../axios';
 import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey';
+import { LOCAL_STORAGE_KEY } from '../../constants/key.ts';
 
 // 설정 - 워크스페이스 프로필 조회
 // - src/pages/onboarding/TokenLoading.tsx
@@ -19,5 +20,16 @@ export const useGetWorkspaceProfile = () => {
   return useQuery({
     queryKey: [queryKey.WORKSPACE_PROFILE],
     queryFn: getWorkspaceProfile,
+    select: (data) => {
+      const inviteUrl = localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl);
+      const invitePassword = localStorage.getItem(LOCAL_STORAGE_KEY.invitePassword);
+      if (!inviteUrl) {
+        localStorage.setItem(LOCAL_STORAGE_KEY.inviteUrl, data.workspaceUrl);
+      }
+      if (!invitePassword) {
+        localStorage.setItem(LOCAL_STORAGE_KEY.invitePassword, data.invitePassword);
+      }
+      return data;
+    },
   });
 };

--- a/src/apis/workspace/usePostCreateWorkspace.ts
+++ b/src/apis/workspace/usePostCreateWorkspace.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { axiosInstance } from '../axios.ts';
 import type { CreateWorkspaceRequest, CreateWorkspaceResponse } from '../../types/workspace.ts';
 import { LOCAL_STORAGE_KEY } from '../../constants/key.ts';
+import { useLocalStorage } from '../../hooks/useLocalStorage.ts';
 
 /**
  * 워크스페이스 생성 요청 함수
@@ -24,9 +25,13 @@ export const usePostCreateWorkspace = () => {
     mutationFn: postCreateWorkspace,
     onSuccess: (data) => {
       if (data.result) {
-        localStorage.setItem(LOCAL_STORAGE_KEY.inviteUrl, data.result.inviteUrl);
-        localStorage.setItem(LOCAL_STORAGE_KEY.invitePassword, data.result.invitePassword);
-        localStorage.setItem(LOCAL_STORAGE_KEY.name, data.result.name);
+        const { setItem: setInviteUrl } = useLocalStorage(LOCAL_STORAGE_KEY.inviteUrl);
+        const { setItem: setInvitePassword } = useLocalStorage(LOCAL_STORAGE_KEY.invitePassword);
+        const { setItem: setName } = useLocalStorage(LOCAL_STORAGE_KEY.name);
+        // 워크스페이스 생성 성공 시 로컬 스토리지에 정보 저장
+        setInviteUrl(data.result.inviteUrl);
+        setInvitePassword(data.result.invitePassword);
+        setName(data.result.name);
       }
     },
   });

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -13,7 +13,9 @@ const ProtectedLayout = () => {
   const isSettingRoute = location.pathname.startsWith('/workspace/setting');
 
   const accessToken = localStorage.getItem(LOCAL_STORAGE_KEY.accessToken);
-  const isLoggedIn = !!accessToken && accessToken !== 'undefined';
+  const workspaceUrl = localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl);
+  const isLoggedIn =
+    !!accessToken && accessToken !== 'undefined' && !!workspaceUrl && workspaceUrl !== 'undefined';
 
   if (!isLoggedIn) {
     return <Navigate to="/onboarding" replace />;

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -7,15 +7,15 @@ import { ErrorBoundary } from 'react-error-boundary';
 import Loading from '../pages/Loading.tsx';
 import ServerError from '../pages/ServerError.tsx';
 import { LOCAL_STORAGE_KEY } from '../constants/key.ts';
+import { useLocalStorage } from '../hooks/useLocalStorage.ts';
 
 const ProtectedLayout = () => {
   const location = useLocation();
   const isSettingRoute = location.pathname.startsWith('/workspace/setting');
 
-  const accessToken = localStorage.getItem(LOCAL_STORAGE_KEY.accessToken);
-  const workspaceUrl = localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl);
-  const isLoggedIn =
-    !!accessToken && accessToken !== 'undefined' && !!workspaceUrl && workspaceUrl !== 'undefined';
+  const { getItem: getAccessToken } = useLocalStorage(LOCAL_STORAGE_KEY.accessToken);
+  const { getItem: getInviteUrl } = useLocalStorage(LOCAL_STORAGE_KEY.inviteUrl);
+  const isLoggedIn = !!getAccessToken() && !!getInviteUrl();
 
   if (!isLoggedIn) {
     return <Navigate to="/onboarding" replace />;

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -37,6 +37,7 @@ export type WorkspaceResponse = {
   workspaceName: string;
   workspaceImageUrl: string;
   workspaceUrl: string;
+  invitePassword: string;
   defaultTeamId: number;
 };
 


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #153

---

### ✅ Key Changes

- 워크스페이스 생성 이후 스토리지에 링크, 비밀번호를 따로 저장하는 로직이 없어 로그아웃 이후 모든 정보가 유실되는 문제점이 발생하였습니다.
따라서, useGetWorkspaceProfile에 select 절을 추가하여 data를 성공적으로 받아왔을 경우 로컬 스토리지에 초대링크, 비밀번호를 저장하도록 로직을 추가하였습니다.

- 로컬 스토리지에 액세스토큰과 비밀번호가 모두 있는지를 체크하여 접근 권한을 파악합니다.

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
- 기존 유저가 로그인하지 않고 protected routes에 접근하는 경우

https://github.com/user-attachments/assets/a3f8103c-32a0-43f2-a3af-121e9cad3102


- 초기 유저가 워크스페이스를 생성하지 않고 protected routes에 접근하는 경우

https://github.com/user-attachments/assets/eebf0c4e-85d4-46da-858c-b0cd273e450a

---

### 💬 To Reviewers
<!-- 팀원들에게 전달하고 싶은 말이나 노티해야되는 내용을 적어주세요. -->
useMutation에서는 onSuccess가 있다면 useQuery에는 select 절이 있다고 하네요~

