### PR TITLE
[FIX] 스크롤 전파 문제 해결 및 회원탈퇴 API 연동

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -64,3 +64,9 @@ export const postLogout = async (): Promise<void> => {
     throw error;
   }
 };
+
+// 설정 - 회원 탈퇴
+export const deleteWithdraw = async () => {
+  const res = await axiosInstance.delete('/api/workspace/setting/my-profile');
+  return res;
+};

--- a/src/components/Sidebar/SettingSidebar.tsx
+++ b/src/components/Sidebar/SettingSidebar.tsx
@@ -9,40 +9,30 @@ const SettingSidebar = () => {
   const { data: workspaceProfile } = useGetWorkspaceProfile();
 
   return (
-    <div
-      className={clsx(
-        'bg-gray-200 transition-all duration-300 ease-in-out',
-        sidebarOpen ? 'w-[30.8rem]' : 'w-[12.8rem]',
-        'h-screen flex flex-col'
-      )}
-    >
+    <div className="bg-gray-200 transition-all duration-300 ease-in-out h-full flex flex-col">
       {/* 💡 스크롤과 커스텀 스크롤바는 이 div에서 담당 */}
       <div className="relative flex-1">
         {/* Full Sidebar */}
         <div
           className={clsx(
-            'absolute inset-0 h-full w-full transition-opacity duration-300',
+            'absolute inset-0 h-full w-full transition-opacity duration-300 ease-in-out',
             sidebarOpen ? 'opacity-100 z-10' : 'opacity-0 pointer-events-none z-0'
           )}
         >
           <div className="h-full overflow-y-auto sidebar-scroll">
-            <FullSettingSidebarContent
-              workspaceProfile={workspaceProfile!}
-            />
+            <FullSettingSidebarContent workspaceProfile={workspaceProfile!} />
           </div>
         </div>
 
         {/* Mini Sidebar */}
         <div
           className={clsx(
-            'absolute inset-0 h-full w-full transition-opacity duration-300',
+            'absolute inset-0 h-full w-full transition-opacity duration-300 ease-in-out',
             !sidebarOpen ? 'opacity-100 z-10' : 'opacity-0 pointer-events-none z-0'
           )}
         >
           <div className="h-full overflow-y-auto sidebar-scroll">
-            <MiniSettingSidebarContent
-              workspaceProfile={workspaceProfile!}
-            />
+            <MiniSettingSidebarContent workspaceProfile={workspaceProfile!} />
           </div>
         </div>
       </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -16,19 +16,13 @@ const Sidebar = () => {
   const myTeams: Team[] = data ? data.pages.flatMap((page) => page.teamList).slice(1) : [];
 
   return (
-    <div
-      className={clsx(
-        'bg-gray-200 transition-all duration-300 ease-in-out',
-        sidebarOpen ? 'w-[30.8rem]' : 'w-[12.8rem]',
-        'h-screen flex flex-col'
-      )}
-    >
+    <div className="bg-gray-200 transition-all duration-300 ease-in-out h-full flex flex-col">
       {/* 💡 스크롤과 커스텀 스크롤바는 이 div에서 담당 */}
       <div className="relative flex-1">
         {/* Full Sidebar */}
         <div
           className={clsx(
-            'absolute inset-0 h-full w-full transition-opacity duration-300',
+            'absolute inset-0 h-full w-full transition-opacity duration-200 ease-in-out',
             sidebarOpen ? 'opacity-100 z-10' : 'opacity-0 pointer-events-none z-0'
           )}
         >
@@ -48,7 +42,7 @@ const Sidebar = () => {
         {/* Mini Sidebar */}
         <div
           className={clsx(
-            'absolute inset-0 h-full w-full transition-opacity duration-300',
+            'absolute inset-0 h-full w-full transition-opacity duration-200 ease-in-out',
             !sidebarOpen ? 'opacity-100 z-10' : 'opacity-0 pointer-events-none z-0'
           )}
         >

--- a/src/constants/sidebar.ts
+++ b/src/constants/sidebar.ts
@@ -1,0 +1,4 @@
+export const SIDEBAR_WIDTH = {
+  FULL: '30.8rem',
+  MINI: '12.8rem',
+};

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -8,6 +8,8 @@ import Loading from '../pages/Loading.tsx';
 import ServerError from '../pages/ServerError.tsx';
 import { LOCAL_STORAGE_KEY } from '../constants/key.ts';
 import { useLocalStorage } from '../hooks/useLocalStorage.ts';
+import { useUIStore } from '../stores/ui.ts';
+import { SIDEBAR_WIDTH } from '../constants/sidebar';
 
 const ProtectedLayout = () => {
   const location = useLocation();
@@ -16,6 +18,7 @@ const ProtectedLayout = () => {
   const { getItem: getAccessToken } = useLocalStorage(LOCAL_STORAGE_KEY.accessToken);
   const { getItem: getInviteUrl } = useLocalStorage(LOCAL_STORAGE_KEY.inviteUrl);
   const isLoggedIn = !!getAccessToken() && !!getInviteUrl();
+  const { sidebarOpen } = useUIStore();
 
   if (!isLoggedIn) {
     return <Navigate to="/onboarding" replace />;
@@ -27,10 +30,16 @@ const ProtectedLayout = () => {
         <ErrorBoundary onReset={reset} FallbackComponent={ServerError}>
           <Suspense fallback={<Loading />}>
             <div className="flex h-screen">
-              <aside className="overflow-auto sidebar-scroll">
+              <aside
+                className="fixed top-0 left-0 h-screen overflow-auto sidebar-scroll transition-all duration-300 ease-in-out"
+                style={{ width: sidebarOpen ? SIDEBAR_WIDTH.FULL : SIDEBAR_WIDTH.MINI }}
+              >
                 {isSettingRoute ? <SettingSidebar /> : <Sidebar />}
               </aside>
-              <main className="flex flex-1 min-w-0 min-h-max overflow-auto basic-scroll">
+              <main
+                className="flex flex-1 overflow-auto basic-scroll transition-all duration-300 ease-in-out"
+                style={{ paddingLeft: sidebarOpen ? SIDEBAR_WIDTH.FULL : SIDEBAR_WIDTH.MINI }}
+              >
                 <Outlet />
               </main>
             </div>

--- a/src/pages/setting/components/modal/WithdrawModal.tsx
+++ b/src/pages/setting/components/modal/WithdrawModal.tsx
@@ -1,5 +1,7 @@
+import { deleteWithdraw } from '../../../../apis/auth.ts';
 import { useModalActions } from '../../../../hooks/useModal.ts';
 import { createPortal } from 'react-dom';
+import { useNavigate } from 'react-router-dom';
 
 interface WithdrawModalProps {
   title?: string;
@@ -17,10 +19,22 @@ const WithdrawModal = ({
   onClose,
 }: WithdrawModalProps) => {
   const { closeModal } = useModalActions();
+  const navigate = useNavigate();
 
   const handleClose = () => {
     closeModal();
     onClose?.();
+  };
+
+  const handleWithdraw = async () => {
+    try {
+      await deleteWithdraw();
+      closeModal();
+      localStorage.clear();
+      navigate('/onboarding');
+    } catch (error) {
+      console.error('회원 탈퇴 실패:', error);
+    }
   };
 
   return createPortal(
@@ -40,7 +54,7 @@ const WithdrawModal = ({
         <div className={`flex justify-end`}>
           <button
             className={`px-[1.6rem] py-[0.8rem] rounded-[0.6rem] text-gray-100 font-small-b ${disabled ? 'bg-gray-300 cursor-not-allowed' : 'bg-error-400 cursor-pointer'}`}
-            onClick={handleClose}
+            onClick={handleWithdraw}
             disabled={disabled}
           >
             탈퇴하기


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #165 
- Closed #168 

---

### ✅ Key Changes

### 🐞 Mac OS에서 사이드바 스크롤 전파 문제 해결

📌 문제 배경

- Mac OS의 트랙패드(특히 자연 스크롤 설정)는 손을 떼더라도 스크롤 이벤트가 관성(momentum)에 의해 계속 전파됩니다.
- 기존 레이아웃 구조에서는 좌측 사이드바(<aside>)와 우측 콘텐츠(<main>)가 같은 스크롤 컨텍스트에 있어, 사용자가 우측 콘텐츠 영역을 끝까지 스크롤한 뒤 손을 떼면, 남은 가속도에 따라 스크롤 이벤트가 좌측 사이드바로 전파되는 현상이 발생했습니다.
- 그 결과, 좌측 사이드바가 의도치 않게 같이 스크롤되어 UX가 저하됐습니다.
<img width="3482" height="2306" alt="image" src="https://github.com/user-attachments/assets/d2d5c080-d3e0-44d1-8c85-27b5962dc379" />
<img width="3586" height="2306" alt="image" src="https://github.com/user-attachments/assets/c9ad60b4-919f-4584-88e3-90e5fdf79467" />

✅ 해결 방법

- 사이드바를 position: fixed로 설정하여 레이아웃 흐름에서 분리했습니다:
```tsx
<aside className="fixed top-0 left-0 h-screen overflow-auto">
  ...
</aside>
```
- 이렇게 하면 사이드바는 뷰포트 기준으로 고정되고, 내부만 별도로 스크롤되며, 스크롤 이벤트가 aside 내부에서 처리되고 상위로 전파되지 않음
- 우측 콘텐츠와 스크롤 이벤트가 완전히 분리되어, Mac 트랙패드에서도 전파되지 않음

🧪 결과

- 트랙패드 환경에서도 스크롤이 각각 독립적으로 작동
- 좌/우 영역 모두 UX 안정성 확보

### 🔒 회원 탈퇴 API 연동

- 현재 회원 탈퇴 시, 백엔드에서는 해당 사용자가 생성한 이슈나 댓글은 조회 대상에서 제외되도록 처리하고 있음
- 다만, 탈퇴 후에도 기존 팀들이 그대로 보이는 문제가 있어 탈퇴 처리 시 소속 팀 연관 데이터도 제외되도록 개선 예정입니다

---

### 📸 스크린샷 or 실행영상
- 회원탈퇴
https://github.com/user-attachments/assets/4f0b5f73-978a-4534-b114-6da2a7b9bc18

---

### 💬 To Reviewers
- 맥 환경 스크롤 테스트는 맥 환경이신 주원님이 테스트 해주셨습니다! @HiJuwon 댓글 작성, 상세 페이지 길게 작성했을 때 이상 없는지 최종 확인 부탁드립니다.
