### PR TITLE
[FEAT] 팀원 초대하기 API 연동

### DIFF
--- a/src/apis/setting/useGetInviteMembers.ts
+++ b/src/apis/setting/useGetInviteMembers.ts
@@ -1,0 +1,22 @@
+import type { InviteMemberResponse } from '../../types/setting.ts';
+import { axiosInstance } from '../axios.ts';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { queryKey } from '../../constants/queryKey.ts';
+
+// 설정 - 팀원 초대
+const getInviteMembers = async (): Promise<InviteMemberResponse> => {
+  try {
+    const response = await axiosInstance.get<InviteMemberResponse>('/api/workspace/setting/invite');
+    return response.data;
+  } catch (error) {
+    console.error('멤버 초대 목록 조회 실패', error);
+    throw error;
+  }
+};
+
+export const useGetInviteMembers = () => {
+  return useSuspenseQuery({
+    queryKey: [queryKey.WORKSPACE_MEMBERS],
+    queryFn: getInviteMembers,
+  });
+};

--- a/src/apis/setting/useGetInviteMembers.ts
+++ b/src/apis/setting/useGetInviteMembers.ts
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey.ts';
 
 // 설정 - 팀원 초대
-const getInviteMembers = async (): Promise<InviteMemberResponse> => {
+export const getInviteMembers = async (): Promise<InviteMemberResponse> => {
   try {
     const response = await axiosInstance.get<InviteMemberResponse>('/api/workspace/setting/invite');
     return response.data;

--- a/src/apis/setting/useGetInviteMembers.ts
+++ b/src/apis/setting/useGetInviteMembers.ts
@@ -17,7 +17,7 @@ export const getInviteMembers = async (): Promise<InviteMemberResponse> => {
 
 export const useGetInviteMembers = () => {
   return useSuspenseQuery({
-    queryKey: [queryKey.WORKSPACE_MEMBERS],
+    queryKey: [queryKey.INVITE_MEMBER],
     queryFn: getInviteMembers,
   });
 };

--- a/src/apis/setting/useGetInviteMembers.ts
+++ b/src/apis/setting/useGetInviteMembers.ts
@@ -4,6 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { queryKey } from '../../constants/queryKey.ts';
 
 // 설정 - 팀원 초대
+// - components/modal/MemberInviteModal.tsx
 export const getInviteMembers = async (): Promise<InviteMemberResponse> => {
   try {
     const response = await axiosInstance.get<InviteMemberResponse>('/api/workspace/setting/invite');

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -22,4 +22,5 @@ export const queryKey = {
   GITHUB_REPOSITORIES: 'github_repositories',
   GITHUB_INSTALLATION_ID: 'github_installation_id',
   COMMENT_LIST: 'comment_list',
+  INVITE_MEMBER: 'invite_member',
 };

--- a/src/pages/setting/SettingMember.tsx
+++ b/src/pages/setting/SettingMember.tsx
@@ -2,20 +2,11 @@ import TeamHeader from './components/TeamHeader.tsx';
 import MemberItem from './components/MemberItem.tsx';
 import { useState } from 'react';
 import MemberInviteModal from './components/modal/MemberInviteModal.tsx';
-import { LOCAL_STORAGE_KEY } from '../../constants/key.ts';
 import { useGetWorkspaceMembers } from '../../apis/setting/useGetWorkspaceMembers.ts';
 import { formatIsoToDot } from '../../utils/formatDate.ts';
-import { useGetWorkspaceProfile } from '../../apis/setting/useGetWorkspaceProfile.ts';
-import { useGetMyProfile } from '../../apis/setting/useGetMyProfile.ts';
 
 const SettingMember = () => {
-  const { data: workspaceProfile } = useGetWorkspaceProfile();
   const { data: members } = useGetWorkspaceMembers();
-  const { data: myProfile } = useGetMyProfile();
-  const inviteUrl =
-    localStorage.getItem(LOCAL_STORAGE_KEY.inviteUrl) || workspaceProfile?.workspaceUrl || '';
-  const invitePassword = localStorage.getItem(LOCAL_STORAGE_KEY.invitePassword) || '';
-  const memberName = localStorage.getItem(LOCAL_STORAGE_KEY.name) || myProfile?.name || '';
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (

--- a/src/pages/setting/SettingMember.tsx
+++ b/src/pages/setting/SettingMember.tsx
@@ -54,14 +54,7 @@ const SettingMember = () => {
               ))}
         </>
       )}
-      {isModalOpen && (
-        <MemberInviteModal
-          memberName={memberName}
-          url={inviteUrl}
-          password={invitePassword}
-          onClick={() => setIsModalOpen(!isModalOpen)}
-        />
-      )}
+      {isModalOpen && <MemberInviteModal onClick={() => setIsModalOpen(false)} />}
     </div>
   );
 };

--- a/src/pages/setting/components/modal/MemberInviteModal.tsx
+++ b/src/pages/setting/components/modal/MemberInviteModal.tsx
@@ -33,7 +33,6 @@ const MemberInviteModal = (props: MemberInviteModalProps) => {
           <textarea
             className={`flex-1 border border-gray-300 rounded-[0.6rem] h-[8rem] px-[1.2rem] py-[0.8rem]
             font-xsmall-r text-gray-600 focus:outline-none resize-none`}
-            disabled={true}
             readOnly={true}
             value={`팀원 URL : ${props.url}\n\n암호 : ${props.password}`}
             ref={inputRef}

--- a/src/pages/setting/components/modal/MemberInviteModal.tsx
+++ b/src/pages/setting/components/modal/MemberInviteModal.tsx
@@ -1,18 +1,37 @@
 import IcX from '../../../../assets/icons/x.svg';
 import CopyToClipboard from '../../../../components/Onboarding/CopyToClipboard.tsx';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ModalButton from './ModalButton.tsx';
+import { getInviteMembers } from '../../../../apis/setting/useGetInviteMembers.ts';
 
 interface MemberInviteModalProps {
-  memberName: string;
-  url: string;
-  password: string;
   onClick: () => void;
 }
 
-const MemberInviteModal = (props: MemberInviteModalProps) => {
+const MemberInviteModal = ({ onClick }: MemberInviteModalProps) => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [inviteData, setInviteData] = useState<{
+    name: string;
+    inviteUrl: string;
+    invitePassword: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const fetchInvite = async () => {
+      try {
+        const data = await getInviteMembers();
+        const inviteData = data.result;
+        console.log(inviteData);
+        setInviteData(inviteData ?? null);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchInvite();
+  }, []);
+
   return createPortal(
     <div className={`fixed inset-0 flex items-center justify-center bg-black/66 z-50`}>
       <div
@@ -22,10 +41,12 @@ const MemberInviteModal = (props: MemberInviteModalProps) => {
         <section>
           <div className={`flex w-full justify-between`}>
             <h2 className={`text-gray-600 font-title-sub-b`}>팀원 초대</h2>
-            <img src={IcX} alt={'닫기'} onClick={props.onClick} />
+            <img src={IcX} alt={'닫기'} onClick={onClick} className="cursor-pointer" />
           </div>
           <p className={`mt-[0.8rem] text-gray-500 font-body-r`}>
-            {`팀원을 ${props.memberName}님의 팀에 초대해봐요`}
+            {inviteData
+              ? `팀원을 ${inviteData.name}님의 팀에 초대해봐요`
+              : '초대 정보를 불러오지 못했어요.'}
           </p>
         </section>
 
@@ -33,14 +54,18 @@ const MemberInviteModal = (props: MemberInviteModalProps) => {
           <textarea
             className={`flex-1 border border-gray-300 rounded-[0.6rem] h-[8rem] px-[1.2rem] py-[0.8rem]
             font-xsmall-r text-gray-600 focus:outline-none resize-none`}
-            readOnly={true}
-            value={`팀원 URL : ${props.url}\n\n암호 : ${props.password}`}
+            readOnly
+            value={
+              inviteData
+                ? `팀원 URL : ${inviteData.inviteUrl}\n\n암호 : ${inviteData.invitePassword}`
+                : ''
+            }
             ref={inputRef}
           />
           <CopyToClipboard inputRef={inputRef} />
         </section>
 
-        <ModalButton text={'닫기'} onClick={props.onClick} />
+        <ModalButton text={'닫기'} onClick={onClick} />
       </div>
     </div>,
     document.body

--- a/src/pages/setting/components/modal/MemberInviteModal.tsx
+++ b/src/pages/setting/components/modal/MemberInviteModal.tsx
@@ -3,7 +3,7 @@ import CopyToClipboard from '../../../../components/Onboarding/CopyToClipboard.t
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ModalButton from './ModalButton.tsx';
-import { getInviteMembers } from '../../../../apis/setting/useGetInviteMembers.ts';
+import { useGetInviteMembers } from '../../../../apis/setting/useGetInviteMembers.ts';
 
 interface MemberInviteModalProps {
   onClick: () => void;
@@ -11,26 +11,21 @@ interface MemberInviteModalProps {
 
 const MemberInviteModal = ({ onClick }: MemberInviteModalProps) => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const { data: inviteMembers } = useGetInviteMembers();
   const [inviteData, setInviteData] = useState<{
     name: string;
     inviteUrl: string;
     invitePassword: string;
   } | null>(null);
-
   useEffect(() => {
-    const fetchInvite = async () => {
-      try {
-        const data = await getInviteMembers();
-        const inviteData = data.result;
-        console.log(inviteData);
-        setInviteData(inviteData ?? null);
-      } catch (err) {
-        console.error(err);
-      }
-    };
-
-    fetchInvite();
-  }, []);
+    if (inviteMembers?.result) {
+      setInviteData({
+        name: inviteMembers.result.name,
+        inviteUrl: inviteMembers.result.inviteUrl,
+        invitePassword: inviteMembers.result.invitePassword,
+      });
+    }
+  }, [inviteMembers]);
 
   return createPortal(
     <div className={`fixed inset-0 flex items-center justify-center bg-black/66 z-50`}>

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -1,3 +1,5 @@
+import type { CommonResponse } from './common';
+
 export type TeamListResponse = {
   teamId: number;
   teamName: string;
@@ -52,3 +54,9 @@ export type MyProfileImageResponse = {
   memberId: number;
   profileImageUrl: string;
 };
+
+export type InviteMemberResponse = CommonResponse<{
+  name: string;
+  inviteUrl: string;
+  invitePassword: string;
+} | null>;


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #176

---

### ✅ Key Changes

- 초대 모달에서 복사 기능이 정상적으로 작동하지 않던 문제를 수정하였습니다.

- **로컬 스토리지에서 inviteUrl 값을 불러오지 않고, 해당 api를 호출하기로 변경한 이유는 다음과 같습니다** (자세한 내용은 첨부된 영상을 참고해 주세요):

  - 로컬 스토리지에 저장된 `inviteUrl`은 실제 팀원을 워크스페이스로 초대할 수 있는 링크가 아니라, 워크스페이스 이름 입력 시 보여주기식으로 제공되는 기본 URL 형식입니다. 예를 들어, https://veco-eight.vercel.app/veco 와 같은 주소입니다.

  - 변수명이 같아 혼동을 줄 수 있으며, 해당 URL을 기반으로 모달을 띄우면 초대 받은 사용자는 링크로 접속이 불가한 문제가 발생합니다. 그런데 해당 값은 과거에 protectedRoutes 접근 권한 여부를 판단하기 위한 용도로 가을님께서 저장해주셨던 것이므로, 현재로서는 삭제하지 않고 유지하는 것이 바람직합니다.

  - 따라서, ‘팀원 초대하기’ 버튼 클릭 시 API 요청을 보내고, 응답 데이터를 기반으로 모달에 정보를 표시하는 방식이 더 적절하다고 판단했습니다.

  - 이 API 호출 함수는 이 모달에서만 사용되므로, useEffect를 사용해 모달이 마운트될 때 딱 한 번만 호출되도록 구현하였습니다.

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://github.com/user-attachments/assets/cc4e0104-28fc-459e-8b3e-340dc2b42c88


---

### 💬 To Reviewers
<!-- 팀원들에게 전달하고 싶은 말이나 노티해야되는 내용을 적어주세요. -->
우선적으로 개발용 서버로 진행했습니다.