### PR TITLE
[FEAT] 사이드바 UX 개선

### DIFF
--- a/src/components/Sidebar/FullSidebarContent.tsx
+++ b/src/components/Sidebar/FullSidebarContent.tsx
@@ -113,7 +113,11 @@ const FullSidebarContent = ({
 
         <div className="flex flex-col items-start self-stretch">
           {/* 첫 번째 드롭다운: 워크스페이스 기본 팀 */}
-          <DropdownMenu dropdownId="ws-default-team" headerTitle="워크스페이스 기본 팀" initialOpen={true}>
+          <DropdownMenu
+            dropdownId="ws-default-team"
+            headerTitle="워크스페이스 기본 팀"
+            initialOpen={true}
+          >
             <div className="flex flex-col">
               {isLoading ? null : (
                 <DropdownMenu
@@ -169,9 +173,11 @@ const FullSidebarContent = ({
           <DropdownMenu dropdownId="my-teams" headerTitle="나의 팀" initialOpen={true}>
             {/* Team 드롭다운 (내부 드롭다운) */}
             {isLoading ? null : myTeams.length === 0 ? (
-              <div className="text-gray-400 font-xsmall-r px-[3rem] pb-[1.6rem]">
-                등록된 팀이 없습니다.
-              </div>
+              <button type="button" onClick={() => navigate('/workspace/setting/team-list')}>
+                <div className="text-gray-400 font-xsmall-r px-[3rem] pb-[1.6rem] cursor-pointer underline underline-offset-[0.3rem]">
+                  팀 생성하기
+                </div>
+              </button>
             ) : (
               <>
                 <SortableDropdownList

--- a/src/components/Sidebar/SidebarItem.tsx
+++ b/src/components/Sidebar/SidebarItem.tsx
@@ -22,12 +22,20 @@ const SidebarItem = ({
         type="button"
         className="flex grow items-center gap-[0.8rem] cursor-pointer"
       >
-        <span className="w-[2.4rem] h-[2.4rem] shrink-0 aspect-square">
+        <span className="w-[2.4rem] h-[2.4rem] shrink-0">
           <span className="block group-hover:hidden">
-            <img src={defaultIcon} alt="defaultIcon" />
+            <img
+              src={defaultIcon}
+              alt="defaultIcon"
+              className="w-full h-full rounded-full object-cover"
+            />
           </span>
           <span className="hidden group-hover:block">
-            <img src={hoverIcon} alt="hoverIcon" />
+            <img
+              src={hoverIcon}
+              alt="hoverIcon"
+              className="w-full h-full rounded-full object-cover"
+            />
           </span>
         </span>
         <span className="font-small-r text-gray-600 letter-spacing-[0.028rem] group-hover:text-primary-blue group-hover:font-bold">

--- a/src/hooks/useAutoCloseSidebar.ts
+++ b/src/hooks/useAutoCloseSidebar.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useUIStore } from '../stores/ui';
+
+export const useAutoCloseSidebar = (breakpoint = 768) => {
+  const { setSidebarOpen } = useUIStore();
+
+  useEffect(() => {
+    console.log('useAutoCloseSidebar');
+    const mediaQuery = window.matchMedia(`(max-width: ${breakpoint}px)`);
+
+    const handleMediaChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      if (e.matches) {
+        setSidebarOpen(false);
+      }
+    };
+
+    handleMediaChange(mediaQuery); // 초기 상태 확인
+    mediaQuery.addEventListener('change', handleMediaChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleMediaChange);
+    };
+  }, [breakpoint, setSidebarOpen]);
+};

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -10,6 +10,7 @@ import { LOCAL_STORAGE_KEY } from '../constants/key.ts';
 import { useLocalStorage } from '../hooks/useLocalStorage.ts';
 import { useUIStore } from '../stores/ui.ts';
 import { SIDEBAR_WIDTH } from '../constants/sidebar';
+import { useAutoCloseSidebar } from '../hooks/useAutoCloseSidebar';
 
 const ProtectedLayout = () => {
   const location = useLocation();
@@ -19,6 +20,8 @@ const ProtectedLayout = () => {
   const { getItem: getInviteUrl } = useLocalStorage(LOCAL_STORAGE_KEY.inviteUrl);
   const isLoggedIn = !!getAccessToken() && !!getInviteUrl();
   const { sidebarOpen } = useUIStore();
+
+  useAutoCloseSidebar();
 
   if (!isLoggedIn) {
     return <Navigate to="/onboarding" replace />;

--- a/src/pages/setting/SettingWorkspaceProfile.tsx
+++ b/src/pages/setting/SettingWorkspaceProfile.tsx
@@ -18,7 +18,7 @@ const SettingWorkspaceProfile = () => {
               <button className="w-[4.2rem] h-[4.2rem] flex items-center justify-center">
                 <img
                   src={workspaceData?.workspaceImageUrl || vecocirclenavy}
-                  className="w-full h-full"
+                  className="w-full h-full rounded-full object-cover"
                   alt="프로필 사진"
                 />
               </button>

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -4,6 +4,7 @@ import { immer } from 'zustand/middleware/immer';
 
 interface UIState {
   sidebarOpen: boolean;
+  setSidebarOpen: (open: boolean) => void;
   toggleSidebar: () => void;
 
   dropdownOpen: Record<string, boolean>;
@@ -15,6 +16,10 @@ export const useUIStore = create<UIState>()(
   persist(
     immer((set) => ({
       sidebarOpen: true,
+      setSidebarOpen: (open) =>
+        set((s) => {
+          s.sidebarOpen = open;
+        }),
       toggleSidebar: () =>
         set((s) => {
           s.sidebarOpen = !s.sidebarOpen;


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #185

---

### ✅ Key Changes

- 사이드바에서 팀 없을시 팀 생성하기 버튼 보여주기
- 사용자 경험을 고려하여 뷰 일정 너비 이하로 줄어들시 사이드바 닫히도록 구현
- 세팅 - 워크스페이스 로고 정사각형 -> 동그랗게 보이도록 수정
  - `rounded-full` 적용

---

### 📸 스크린샷 or 실행영상

https://github.com/user-attachments/assets/e56a2083-3ddb-439a-8963-daaee9c65e22
- 팀이 없을시 사이드바에 팀 생성하기 버튼이 있으며, 뷰가 일정 너비 이하로 줄어들시 사이드바가 닫힙니다.
- 일정 너비 이상이 되었을 때 사이드바가 다시 열리는 건 사용자에게 혼란스러울 수 있다고 생각하여, 닫히는 것만 먼저 구현하였습니다.
<img width="1919" height="857" alt="image" src="https://github.com/user-attachments/assets/95379b4c-83fb-4378-b0c2-2ec0acc892f4" />


---

### 💬 To Reviewers
- 현재 개발 서버에서 인증 관련 테스트 중이어서 액세스 토큰 만료 시간이 짧은 걸로 알고 있습니다. 테스트 중에 에러가 뜰 시 당황하지 마시고 온보딩 페이지에서 재로그인 해주시면 됩니다.