### PR TITLE
[REFACTOR] 상세페이지 반응형 수정

### DIFF
--- a/src/pages/external/ExternalDetail.tsx
+++ b/src/pages/external/ExternalDetail.tsx
@@ -476,14 +476,14 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem]">
+    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] overflow-x-auto basic-scroll">
       {/* 상세페이지 헤더 */}
       <DetailHeader type={'external'} defaultTitle="제목을 작성해보세요" title={title} />
 
       {/* 상세페이지 메인 */}
-      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-h-max">
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-w-max min-h-max">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-h-max">
+        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-w-[40rem] min-h-max">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="제목을 작성해보세요"
@@ -514,7 +514,7 @@ const ExternalDetail = ({ initialMode }: ExternalDetailProps) => {
         </div>
 
         {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
-        <div className="w-[33rem] flex flex-col min-h-max">
+        <div className="min-w-[33rem] flex flex-col min-h-max">
           {/* 속성 탭 */}
           <div className="w-full h-full flex flex-col gap-[1.6rem] ">
             <div className="w-full font-title-sub-r text-gray-600">속성</div>

--- a/src/pages/goal/GoalDetail.tsx
+++ b/src/pages/goal/GoalDetail.tsx
@@ -340,14 +340,14 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem]">
+    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] overflow-x-auto basic-scroll">
       {/* 상세페이지 헤더 */}
       <DetailHeader type={'goal'} defaultTitle="목표를 생성하세요" title={title} />
 
       {/* 상세페이지 메인 */}
-      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-h-max">
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-w-max min-h-max">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-h-max">
+        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-w-[40rem] min-h-max">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="목표를 생성하세요"
@@ -378,7 +378,7 @@ const GoalDetail = ({ initialMode }: GoalDetailProps) => {
         </div>
 
         {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
-        <div className="w-[33rem] flex flex-col min-h-max">
+        <div className="min-w-[33rem] flex flex-col min-h-max">
           {/* 속성 탭 */}
           <div className="w-full h-full flex flex-col gap-[1.6rem] ">
             <div className="w-full font-title-sub-r text-gray-600">속성</div>

--- a/src/pages/issue/IssueDetail.tsx
+++ b/src/pages/issue/IssueDetail.tsx
@@ -355,14 +355,14 @@ const IssueDetail = ({ initialMode }: IssueDetailProps) => {
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem]">
+    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] overflow-x-auto basic-scroll">
       {/* 상세페이지 헤더 */}
       <DetailHeader type={'issue'} defaultTitle="이슈를 생성하세요" title={title} />
 
       {/* 상세페이지 메인 */}
-      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-h-max">
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-w-max min-h-max">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-h-max">
+        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-w-[40rem] min-h-max">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="이슈를 생성하세요"
@@ -393,7 +393,7 @@ const IssueDetail = ({ initialMode }: IssueDetailProps) => {
         </div>
 
         {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
-        <div className="w-[33rem] flex flex-col min-h-max">
+        <div className="min-w-[33rem] flex flex-col min-h-max">
           {/* 속성 탭 */}
           <div className="w-full h-full flex flex-col gap-[1.6rem] ">
             <div className="w-full font-title-sub-r text-gray-600">속성</div>

--- a/src/pages/workspace/WorkspaceExternalDetail.tsx
+++ b/src/pages/workspace/WorkspaceExternalDetail.tsx
@@ -477,14 +477,14 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem]">
+    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] overflow-x-auto basic-scroll">
       {/* 상세페이지 헤더 */}
       <WorkspaceDetailHeader type={'external'} defaultTitle="제목을 작성해보세요" title={title} />
 
       {/* 상세페이지 메인 */}
-      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-h-max">
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-w-max min-h-max">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-h-max">
+        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-w-[40rem] min-h-max">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="제목을 작성해보세요"
@@ -515,7 +515,7 @@ const WorkspaceExternalDetail = ({ initialMode }: WorkspaceExternalDetailProps) 
         </div>
 
         {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
-        <div className="w-[33rem] flex flex-col min-h-max">
+        <div className="min-w-[33rem] flex flex-col min-h-max">
           {/* 속성 탭 */}
           <div className="w-full h-full flex flex-col gap-[1.6rem] ">
             <div className="w-full font-title-sub-r text-gray-600">속성</div>

--- a/src/pages/workspace/WorkspaceGoalDetail.tsx
+++ b/src/pages/workspace/WorkspaceGoalDetail.tsx
@@ -343,14 +343,14 @@ const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem]">
+    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] overflow-x-auto basic-scroll">
       {/* 상세페이지 헤더 */}
       <WorkspaceDetailHeader type={'goal'} defaultTitle="목표를 생성하세요" title={title} />
 
       {/* 상세페이지 메인 */}
-      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-h-max">
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-w-max min-h-max">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] min-h-max">
+        <div className="flex flex-col gap-[3.2rem] w-[calc(100%-33rem)] min-w-[40rem] min-h-max">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="목표를 생성하세요"
@@ -381,7 +381,7 @@ const WorkspaceGoalDetail = ({ initialMode }: WorkspaceGoalDetailProps) => {
         </div>
 
         {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
-        <div className="w-[33rem] flex flex-col min-h-max">
+        <div className="min-w-[33rem] flex flex-col min-h-max">
           {/* 속성 탭 */}
           <div className="w-full h-full flex flex-col gap-[1.6rem] ">
             <div className="w-full font-title-sub-r text-gray-600">속성</div>

--- a/src/pages/workspace/WorkspaceIssueDetail.tsx
+++ b/src/pages/workspace/WorkspaceIssueDetail.tsx
@@ -355,14 +355,14 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem]">
+    <div className="flex flex-1 flex-col min-h-max gap-[5.7rem] w-full px-[3.2rem] pt-[3.2rem] overflow-x-auto basic-scroll">
       {/* 상세페이지 헤더 */}
       <WorkspaceDetailHeader type={'issue'} defaultTitle="이슈를 생성하세요" title={title} />
 
       {/* 상세페이지 메인 */}
-      <div className="flex px-[3.2rem] gap-[8.8rem] w-full min-h-max">
+      <div className="flex px-[3.2rem] gap-[8.8rem] w-ful min-w-max min-h-max">
         {/* 상세페이지 좌측 영역 - 제목 & 상세설명 & 댓글 */}
-        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-h-max">
+        <div className="flex flex-col flex-1 gap-[3.2rem] w-[calc(100%-33rem)] min-w-[40rem] min-h-max">
           {/* 상세페이지 제목 */}
           <DetailTitle
             defaultTitle="이슈를 생성하세요"
@@ -393,7 +393,7 @@ const WorkspaceIssueDetail = ({ initialMode }: WorkspaceIssueDetailProps) => {
         </div>
 
         {/* 상세페이지 우측 영역 - 속성 탭 & 하단의 작성 완료 버튼 */}
-        <div className="w-[33rem] flex flex-col min-h-max">
+        <div className="min-w-[33rem] flex flex-col min-h-max">
           {/* 속성 탭 */}
           <div className="w-full h-full flex flex-col gap-[1.6rem] ">
             <div className="w-full font-title-sub-r text-gray-600">속성</div>


### PR DESCRIPTION
### 체크리스트

- [x] 🧰 npm run dev로 실행 환경에서 잘 돌아가는걸 확인했나요?
- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙆 리뷰어는 등록했나요?

---

### 📌 관련 이슈번호

- Closed #196 

---

### ✅ Key Changes

#### 반응형 문제점: 기존에는 뷰포트 가로 너비가 좁아지면 아래와 같이 나타났습니다.
- 상세페이지 우측 영역(속성 탭이 있는 영역)에 width 고정값 33rem이 적용되어 있었음
- 때문에 일정 이상 뷰포트 너비가 줄어들면 상세페이지 좌측 영역(제목, 텍스트에디터, 댓글창이 있는 영역)이 심하게 줄어들었습니다.
<img width="1011" height="1150" alt="스크린샷 2025-08-22 오전 2 26 37" src="https://github.com/user-attachments/assets/edf49e68-27e4-424e-b47c-f373f4a74604" />


#### 뷰포트 가로 너비가 좁아질 경우에 대비해 상세페이지 반응형을 수정했습니다.
- 상세페이지 좌측 영역(제목, 텍스트에디터, 댓글창이 있는 영역): `최소 width를 40rem`으로` 설정
- 상세페이지 우측 영역(속성 탭이 있는 영역): width를 고정적으로 33rem으로 하지 않고, `최소 width를 33rem`으로 변경
- 좌측 영역과 우측 영역을 감싸는 래퍼 컨테이너: `min-w-max` 속성을 적용하여 자식 요소들의 가로 너비만큼을 최소 너비로 차지하게끔 처리
- 최상위 컨테이너: `overflow-x-auto` 속성을 적용하여 뷰포트 가로 너비가 자식 요소들이 차지하는 영역보다 좁아지면 자동으로 스크롤되게끔 처리
=> 이를 통해 일정 이상 줄어들면 상세페이지 내부 영역들이 심하게 줄어들지 않고, 전체 페이지의 가로 스크롤바가 생기게 하여 영역을 지키도록 수정했습니다.

<br>

---

### 📸 스크린샷 or 실행영상

중점으로 볼 것:
- 뷰포트 가로 너비가 일정 이상 줄어들면 하단에 가로 스크롤바가 나타나고
- 더이상 상세페이지 좌측/우측 영역 중 하나가 심하게 줄어들지 않음

https://github.com/user-attachments/assets/3bdaeba5-90f6-46dc-8db7-6f22917dc95e


---

### 💬 To Reviewers

